### PR TITLE
Initial support for handling inline arguments and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # hack-graphql
+
 Playground for a hack graphql server

--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -4,30 +4,54 @@ use namespace Facebook\TypeAssert;
 
 // TODO: this should be private
 abstract class BaseSchema {
-    abstract public static function resolveQuery(\Graphpinator\Parser\Operation\Operation $operation): Awaitable<mixed>;
+    abstract public static function resolveQuery(
+        \Graphpinator\Parser\Operation\Operation $operation,
+        __Private\Variables $variables,
+    ): Awaitable<mixed>;
 
     public static async function resolveField<TGraphQLType as \Slack\GraphQL\Types\ObjectType, THackType>(
         \Graphpinator\Parser\Field\Field $field,
         TGraphQLType $parent_type,
         THackType $parent,
+        __Private\Variables $variables,
     ): Awaitable<mixed> where THackType = TGraphQLType::THackType {
         $field_name = $field->getName();
         $field_type = $parent_type::resolveType($field_name);
+
+        $field_args = vec[];
+        foreach ($field->getArguments() ?? vec[] as $field_arg) {
+            $value_type = $field_arg->getValue();
+
+            if ($value_type is \Graphpinator\Parser\Value\VariableRef) {
+                $value = $variables[$value_type->getVarName()];
+            } else {
+                $value = $field_arg->getValue()->getRawValue();
+            }
+
+            $field_args[] = new __Private\Argument($value);
+        }
 
         // This TypeAssert enforces that resolveType and resolveField are
         // consistent for $field_name.
         $field_value = TypeAssert\matches_type_structure(
             \HH\type_structure($field_type, 'THackType'),
-            await $parent_type::resolveField($field_name, $parent),
+            await $parent_type::resolveField($field_name, $parent, $field_args),
         );
 
         if (!$field_type is \Slack\GraphQL\Types\ObjectType) {
             return $field_value;
         }
 
+        // TODO: If field_type is ListType, iterate over the children calling resolveField?
+
         $child_data = dict[];
-        foreach (($field->getFields() as nonnull)->getFields() as $child_field) { // TODO: ->getFragments()
-            $child_data[$child_field->getName()] = await self::resolveField($child_field, $field_type, $field_value);
+        foreach ($field->getFields()?->getFields() ?? vec[] as $child_field) {
+            $child_data[$child_field->getName()] = await self::resolveField(
+                $child_field,
+                $field_type,
+                $field_value,
+                $variables,
+            );
         }
         return $child_data;
     }

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -36,7 +36,8 @@ abstract class BaseObject<T as Field> implements GeneratableObjectType {
             ->setPublic()
             ->setReturnType('Awaitable<mixed>')
             ->addParameter('string $field_name')
-            ->addParameter($this->getResolveFieldResolvedParentParameter());
+            ->addParameter($this->getResolveFieldResolvedParentParameter())
+            ->addParameter($this->getResolveFieldArgumentsParameter());
 
         $hb = hb($cg);
         $hb->startSwitch('$field_name')
@@ -54,6 +55,11 @@ abstract class BaseObject<T as Field> implements GeneratableObjectType {
         $method->setBody($hb->getCode());
 
         return $method;
+    }
+
+    private function getResolveFieldArgumentsParameter(): string {
+        $var_name = C\any($this->fields, $field ==> $field->hasArguments()) ? '$args' : '$_args';
+        return Str\format('vec<\Slack\GraphQL\__Private\Argument> %s', $var_name);
     }
 
     protected function generateResolveType(HackCodegenFactory $cg): CodegenMethod {
@@ -151,9 +157,10 @@ class Field {
         }
 
         $hb->returnCasef(
-            '%s$resolved_parent->%s()',
+            '%s$resolved_parent->%s(%s)',
             $return_prefix,
             $this->method_decl->getFunctionDeclHeader()->getName()->getText(),
+            $this->getArgumentInvocationString(),
         );
     }
 
@@ -196,6 +203,33 @@ class Field {
         }
     }
 
+    public function hasArguments(): bool {
+        return $this->reflection_method->getNumberOfParameters() > 0;
+    }
+
+    protected function getArgumentInvocationString(): string {
+        $invocations = vec[];
+        foreach ($this->reflection_method->getParameters() as $index => $param) {
+            $as_type = $this->getArgumentAsTypeString($param);
+            $invocations[] = Str\format('$args[%d]->%s()', $index, $as_type);
+        }
+
+        return Str\join($invocations, ', ');
+    }
+
+    private function getArgumentAsTypeString(\ReflectionParameter $param): string {
+        switch ($param->getTypeText()) {
+            case 'HH\string':
+                return 'asString';
+            case 'HH\int':
+                return 'asInt';
+            case 'HH\bool':
+                return 'asBool';
+            default:
+                return 'asMixed';
+        }
+    }
+
 }
 
 class QueryField extends Field {
@@ -211,10 +245,11 @@ class QueryField extends Field {
         }
 
         $hb->returnCasef(
-            '%s\%s::%s()',
+            '%s\%s::%s(%s)',
             $return_prefix,
             $class_name,
             $this->method_decl->getFunctionDeclHeader()->getName()->getText(),
+            $this->getArgumentInvocationString(),
         );
     }
 }
@@ -260,14 +295,15 @@ final class Generator {
             ->setIsStatic(true)
             ->setIsAsync(true)
             ->setReturnType('Awaitable<mixed>')
-            ->addParameterf('\%s $operation', \Graphpinator\Parser\Operation\Operation::class);
+            ->addParameterf('\%s $operation', \Graphpinator\Parser\Operation\Operation::class)
+            ->addParameterf('\%s $variables', \Slack\GraphQL\__Private\Variables::class);
 
         $hb = hb($cg)
             ->addAssignment('$query', 'new Query()', HackBuilderValues::literal())
             ->ensureEmptyLine()
             ->addAssignment('$data', 'dict[]', HackBuilderValues::literal())
             ->startForeachLoop('$operation->getFields()->getFields()', null, '$field') // TODO: ->getFragments()
-            ->addLine('$data[$field->getName()] = self::resolveField($field, $query, null);')
+            ->addLine('$data[$field->getName()] = self::resolveField($field, $query, null, $variables);')
             ->endForeachLoop()
             ->ensureEmptyLine()
             ->addReturn('await Dict\from_async($data)', HackBuilderValues::literal());

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -15,22 +15,6 @@ use type Facebook\HackCodegen\{
     HackBuilderValues,
 };
 
-// - [x] support searching for classes and printing out the name
-// - [x] support searching for methods tagged with GraphQLField
-// - [ ] support inspecting the method args for any method tagged GraphQLField
-// - [x] support codegening a class for any GraphQLObject
-// - [x] support codegening the query
-// - [ ] support codegening the schema
-
-// collect the objects
-// - name of the graphql object
-// - name of the class it decorates
-// - fields in the object
-
-// collect the fields in an object
-// - name of the field
-// - method + arg info for the method
-
 function hb(HackCodegenFactory $cg): HackBuilder {
     return new HackBuilder($cg->getConfig());
 }

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -269,7 +269,6 @@ final class Generator {
             ->setDoClobber(true)
             ->setGeneratedFrom($this->cg->codegenGeneratedFromScript())
             ->setFileType(CodegenFileType::DOT_HACK)
-            ->setNamespace('Slack\GraphQL\Test\Generated')
             ->useNamespace('HH\Lib\Dict')
             ->addClass($this->generateSchemaType($this->cg));
 
@@ -280,7 +279,6 @@ final class Generator {
             $file->addClass($class);
         }
 
-        $file->save();
         return $file;
     }
 

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -5,7 +5,9 @@ final class Resolver {
 
     public async function resolve(
         \Graphpinator\Parser\ParsedRequest $request,
+        ?dict<string, mixed> $variables = null,
     ): Awaitable<shape('data' => ?dict<string, mixed>, ?'errors' => vec<string>)> {
+        // TODO: validate variables against $schema
         $schema = $this->schema;
 
         // TODO: what does the spec say should actually be contained in the output?
@@ -14,7 +16,7 @@ final class Resolver {
             $operation_type = $operation->getType();
             switch ($operation_type) {
                 case 'query':
-                    $data = await $schema::resolveQuery($operation);
+                    $data = await $schema::resolveQuery($operation, $variables ?? dict[]);
                     break;
                 default:
                     throw new \Error('Unsupported operation: '.$operation_type);

--- a/src/Types/ObjecType.hack
+++ b/src/Types/ObjecType.hack
@@ -4,6 +4,7 @@ abstract class ObjectType extends BaseType {
     abstract public static function resolveField(
         string $field_name,
         this::THackType $resolved_parent,
+        vec<\Slack\GraphQL\__Private\Argument> $args,
     ): Awaitable<mixed>;
 
     abstract public static function resolveType(string $field_name): BaseType;

--- a/src/__Private/Argument.hack
+++ b/src/__Private/Argument.hack
@@ -1,0 +1,13 @@
+namespace Slack\GraphQL\__Private;
+
+final class Argument {
+    public function __construct(private mixed $value) {}
+
+    public function asInt(): int {
+        return $this->value as int;
+    }
+
+    public function asString(): string {
+        return $this->value as string;
+    }
+}

--- a/src/__Private/Argument.hack
+++ b/src/__Private/Argument.hack
@@ -10,4 +10,12 @@ final class Argument {
     public function asString(): string {
         return $this->value as string;
     }
+
+    public function asBool(): bool {
+        return $this->value as bool;
+    }
+
+    public function asMixed(): mixed {
+        return $this->value;
+    }
 }

--- a/src/__Private/Variables.hack
+++ b/src/__Private/Variables.hack
@@ -1,0 +1,3 @@
+namespace Slack\GraphQL\__Private;
+
+type Variables = dict<string, mixed>;

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -91,4 +91,9 @@ abstract final class UserQueryAttributes {
     public static async function getViewer(): Awaitable<\User> {
         return new \User(shape('id' => 1, 'name' => 'Test User', 'team_id' => 1));
     }
+
+    <<GraphQL\QueryRootField('user', 'Fetch a user by ID')>>
+    public static async function getUser(int $id): Awaitable<\User> {
+        return new \User(shape('id' => $id, 'name' => 'User '.$id, 'team_id' => 1));
+    }
 }

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -4,13 +4,13 @@ use namespace Slack\GraphQL;
 
 final class PlaygroundTest extends \Facebook\HackTest\HackTest {
 
-    // public static async function beforeFirstTestAsync(): Awaitable<void> {
-    //     $gen = new GraphQL\Codegen\Generator();
+    public static async function beforeFirstTestAsync(): Awaitable<void> {
+        $gen = new GraphQL\Codegen\Generator();
 
-    //     $from_path = __DIR__.'/../src/playground/Playground.hack';
-    //     $to_path = __DIR__.'/gen/Generated.hack';
-    //     await $gen->generate($from_path, $to_path);
-    // }
+        $from_path = __DIR__.'/../src/playground/Playground.hack';
+        $to_path = __DIR__.'/gen/Generated.hack';
+        await $gen->generate($from_path, $to_path);
+    }
 
     public async function testSelectTeamId(): Awaitable<void> {
         $source = new \Graphpinator\Source\StringSource('query { viewer { id, team { id } } }');

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -9,7 +9,10 @@ final class PlaygroundTest extends \Facebook\HackTest\HackTest {
 
         $from_path = __DIR__.'/../src/playground/Playground.hack';
         $to_path = __DIR__.'/gen/Generated.hack';
-        await $gen->generate($from_path, $to_path);
+
+        $file = await $gen->generate($from_path, $to_path);
+        $file->setNamespace('Slack\GraphQL\Test\Generated');
+        $file->save();
     }
 
     public async function testSelectTeamId(): Awaitable<void> {

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -14,6 +14,7 @@ abstract final class Schema extends \Slack\GraphQL\BaseSchema {
 
   public static async function resolveQuery(
     \Graphpinator\Parser\Operation\Operation $operation,
+    \Slack\GraphQL\__Private\Variables $variables,
   ): Awaitable<mixed> {
     $query = new Query();
 
@@ -33,10 +34,13 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
   public static async function resolveField(
     string $field_name,
     self::THackType $_,
+    vec<\Slack\GraphQL\__Private\Argument> $args,
   ): Awaitable<mixed> {
     switch ($field_name) {
       case 'viewer':
         return await \UserQueryAttributes::getViewer();
+      case 'user':
+        return await \UserQueryAttributes::getUser($args[0]->asInt());
       default:
         throw new \Error('Unknown field: '.$field_name);
     }
@@ -47,6 +51,8 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
   ): \Slack\GraphQL\Types\BaseType {
     switch ($field_name) {
       case 'viewer':
+        return new User();
+      case 'user':
         return new User();
       default:
         throw new \Error('Unknown field: '.$field_name);
@@ -61,6 +67,7 @@ final class User extends \Slack\GraphQL\Types\ObjectType {
   public static async function resolveField(
     string $field_name,
     self::THackType $resolved_parent,
+    vec<\Slack\GraphQL\__Private\Argument> $_args,
   ): Awaitable<mixed> {
     switch ($field_name) {
       case 'id':
@@ -97,6 +104,7 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
   public static async function resolveField(
     string $field_name,
     self::THackType $resolved_parent,
+    vec<\Slack\GraphQL\__Private\Argument> $_args,
   ): Awaitable<mixed> {
     switch ($field_name) {
       case 'id':

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -1,11 +1,10 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * To re-generate this file run
- * /home/jjergus/work/code/hack-graphql/vendor/hhvm/hacktest/bin/hacktest
+ * To re-generate this file run /app/vendor/hhvm/hacktest/bin/hacktest
  *
  *
- * @generated SignedSource<<981365a30664f9cfd393e3dba99fbd01>>
+ * @generated SignedSource<<75ebd5727cc237efda4eb10f6dceec7b>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace HH\Lib\Dict;
@@ -20,7 +19,7 @@ abstract final class Schema extends \Slack\GraphQL\BaseSchema {
 
     $data = dict[];
     foreach ($operation->getFields()->getFields() as $field) {
-      $data[$field->getName()] = self::resolveField($field, $query, null);
+      $data[$field->getName()] = self::resolveField($field, $query, null, $variables);
     }
 
     return await Dict\from_async($data);


### PR DESCRIPTION
Addresses: https://github.com/mwildehahn/hack-graphql/issues/5

I skipped over validating the arguments just to get this working. I think we'll want to do something [similar to graphpinator](https://github.com/infinityloop-dev/graphpinator/blob/master/src/Graphpinator.php#L69) where they'll "normalize" the request, validating it and any specified arguments against the schema.

I looked at trying to just bring this logic in to get us started but it is a lot of PHP code that is at odds with our generated types.

**Testing**
- Added two test cases, one for variables and one for inline args.