### PR TITLE
Use DefinitionFinder over raw AST

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
   ],
   "require": {
     "hhvm/hsl": "^4.41.0",
-    "facebook/hack-codegen": "^v4.3.12"
+    "facebook/hack-codegen": "^v4.3.12",
+    "facebook/definition-finder": "^v2.13.5"
   },
   "require-dev": {
     "hhvm/hhast": "^4.53.4",

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -276,19 +276,19 @@ final class Generator {
         ?'codegen_config' => IHackCodegenConfig,
     );
 
-    private function __construct(private DefinitionFinder\BaseParser $parser, private self::TGeneratorConfig $conifg) {
-        $this->cg = new HackCodegenFactory($conifg['codegen_config'] ?? new HackCodegenConfig());
+    private function __construct(private DefinitionFinder\BaseParser $parser, private self::TGeneratorConfig $config) {
+        $this->cg = new HackCodegenFactory($config['codegen_config'] ?? new HackCodegenConfig());
     }
 
-    public static async function forPath(string $path, self::TGeneratorConfig $conifg): Awaitable<CodegenFile> {
+    public static async function forPath(string $path, self::TGeneratorConfig $config): Awaitable<CodegenFile> {
         $defs = await DefinitionFinder\TreeParser::fromPathAsync($path);
-        $gen = new self($defs, $conifg);
+        $gen = new self($defs, $config);
         return await $gen->generate();
     }
 
-    public static async function forFile(string $filename, self::TGeneratorConfig $conifg): Awaitable<CodegenFile> {
+    public static async function forFile(string $filename, self::TGeneratorConfig $config): Awaitable<CodegenFile> {
         $defs = await DefinitionFinder\FileParser::fromFileAsync($filename);
-        $gen = new self($defs, $conifg);
+        $gen = new self($defs, $config);
         return await $gen->generate();
     }
 
@@ -296,7 +296,7 @@ final class Generator {
         $objects = await $this->collectObjects();
 
         $file = $this->cg
-            ->codegenFile($this->conifg['output_path'])
+            ->codegenFile($this->config['output_path'])
             ->setDoClobber(true)
             ->setGeneratedFrom($this->cg->codegenGeneratedFromScript())
             ->setFileType(CodegenFileType::DOT_HACK)

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -5,12 +5,13 @@ use namespace Slack\GraphQL;
 final class PlaygroundTest extends \Facebook\HackTest\HackTest {
 
     public static async function beforeFirstTestAsync(): Awaitable<void> {
-        $gen = new GraphQL\Codegen\Generator();
+        $file = await GraphQL\Codegen\Generator::forFile(
+            __DIR__.'/../src/playground/Playground.hack',
+            shape(
+                'output_path' => __DIR__.'/gen/Generated.hack',
+            ),
+        );
 
-        $from_path = __DIR__.'/../src/playground/Playground.hack';
-        $to_path = __DIR__.'/gen/Generated.hack';
-
-        $file = await $gen->generate($from_path, $to_path);
         $file->setNamespace('Slack\GraphQL\Test\Generated');
         $file->save();
     }

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -1,11 +1,10 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * To re-generate this file run
- * /home/jjergus/work/code/hack-graphql/vendor/hhvm/hacktest/bin/hacktest
+ * To re-generate this file run /app/vendor/hhvm/hacktest/bin/hacktest
  *
  *
- * @generated SignedSource<<bab62eaa97c20d0d14b9a58a4d7c07ae>>
+ * @generated SignedSource<<bc4c3fa7e3012e4fded841b97e61ec64>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;


### PR DESCRIPTION
Fix for: https://github.com/mwildehahn/hack-graphql/issues/17.

DefinitionFinder supports parsing from a file or path. This lets us move beyond parsing a single file.

We now support generating graphql types for a path:
```
Generator::forPath($path);
```

or a file name:

```
Generator::forFile($path);
```