### PR TITLE
use DataProvider in PlaygroundTest

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -298,7 +298,7 @@ final class Generator {
         $file = $this->cg
             ->codegenFile($this->config['output_path'])
             ->setDoClobber(true)
-            ->setGeneratedFrom($this->cg->codegenGeneratedFromScript())
+            ->setGeneratedFrom($this->cg->codegenGeneratedFromScript('vendor/bin/hacktest'))
             ->setFileType(CodegenFileType::DOT_HACK)
             ->useNamespace('Slack\\GraphQL')
             ->useNamespace('Slack\\GraphQL\\Types')

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -6,7 +6,7 @@ final class Resolver {
     public async function resolve(
         \Graphpinator\Parser\ParsedRequest $request,
         ?dict<string, mixed> $variables = null,
-    ): Awaitable<shape('data' => ?dict<string, mixed>, ?'errors' => vec<string>)> {
+    ): Awaitable<shape(?'data' => mixed, ?'errors' => vec<string>)> {
         // TODO: validate variables against $schema
         $schema = $this->schema;
 
@@ -26,7 +26,7 @@ final class Resolver {
                     throw new \Error('Unsupported operation: '.$operation_type);
             }
 
-            $out['data'][$operation_type] = $data->getValue();
+            $out['data'] = $data->getValue();
         }
 
         return $out;

--- a/tests/BasicTest.hack
+++ b/tests/BasicTest.hack
@@ -1,0 +1,85 @@
+use function Facebook\FBExpect\expect;
+use namespace HH\Lib\C;
+use namespace Slack\GraphQL;
+
+final class BasicTest extends PlaygroundTest {
+
+    <<__Override>>
+    public static function getTestCases(): dict<string, (string, dict<string, mixed>, dict<string, mixed>)> {
+        return dict[
+            'select team.id' => tuple(
+                'query { viewer { id, team { id } } }',
+                dict[],
+                dict['viewer' => dict['id' => 1, 'team' => dict['id' => 1]]],
+            ),
+            'select is_active' => tuple(
+                'query { viewer { is_active } }',
+                dict[],
+                dict['viewer' => dict['is_active' => true]],
+            ),
+            'select team.name' => tuple(
+                'query { viewer { team { name, num_users } } }',
+                dict[],
+                dict['viewer' => dict['team' => dict['name' => 'Test Team 1', 'num_users' => 3]]],
+            ),
+            'variables' => tuple(
+                'query TestQuery($user_id: ID!) { user(id: $user_id) { id } }',
+                dict['user_id' => 3],
+                dict['user' => dict['id' => 3]],
+            ),
+            'nested variables' => tuple(
+                'query TestQuery($num: Int!) { nested_list_sum(numbers: [21, [$num, 14]]) }',
+                dict['num' => 7],
+                dict['nested_list_sum' => 42],
+            ),
+            'inline arguments' => tuple(
+                'query { user(id: 2) { id } }',
+                dict[],
+                dict['user' => dict['id' => 2]],
+            ),
+            'select concrete implementation' => tuple(
+                'query { human(id: 2) { id, name, favorite_color } }',
+                dict[],
+                dict['human' => dict['id' => 2, 'name' => 'User 2', 'favorite_color' => 'blue']],
+            ),
+            'boolean input true' => tuple(
+                'query TestQuery($short: Boolean!) { user(id: 2) { id, team { description(short: $short) } } }',
+                dict['short' => true],
+                dict['user' => dict['id' => 2, 'team' => dict['description' => 'Short description']]],
+            ),
+            'boolean input false' => tuple(
+                'query TestQuery($short: Boolean!) { user(id: 2) { id, team { description(short: $short) } } }',
+                dict['short' => false],
+                dict['user' => dict['id' => 2, 'team' => dict['description' => 'Much longer description']]],
+            ),
+            'mutation' => tuple(
+                'mutation { pokeUser(id: 2) { id } }',
+                dict[],
+                dict['pokeUser' => dict['id' => 2]],
+            ),
+        ];
+    }
+
+    public async function testSelectInvalidFieldOnInterface(): Awaitable<void> {
+        $source = new \Graphpinator\Source\StringSource('query { user(id: 2) { id, name, favorite_color } }');
+        $parser = new \Graphpinator\Parser\Parser($source);
+
+        $request = $parser->parse();
+        $resolver = new GraphQL\Resolver(\Slack\GraphQL\Test\Generated\Schema::class);
+
+        expect(async () ==> await $resolver->resolve($request))
+            ->toThrow(\Exception::class, "Unknown field: favorite_color");
+    }
+
+    public async function testSelectInvalidFieldOnConcreteImplementation(): Awaitable<void> {
+        $source = new \Graphpinator\Source\StringSource('query { bot(id: 2) { id, name, favorite_color } }');
+        $parser = new \Graphpinator\Parser\Parser($source);
+
+        $request = $parser->parse();
+        $resolver = new GraphQL\Resolver(\Slack\GraphQL\Test\Generated\Schema::class);
+
+        expect(async () ==> await $resolver->resolve($request))
+            ->toThrow(\Exception::class, "Unknown field: favorite_color");
+    }
+
+}

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -1,10 +1,10 @@
 /**
  * This file is generated. Do not modify it manually!
  *
- * To re-generate this file run /app/vendor/hhvm/hacktest/bin/hacktest
+ * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<bc4c3fa7e3012e4fded841b97e61ec64>>
+ * @generated SignedSource<<945571f40a6716a8089241b62efc534a>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;


### PR DESCRIPTION
- use DataProvider to avoid some duplicate code
- use base class + separate test class: this allows people to add multiple tests that behave the same way, so we don't get merge conflicts from everyone modifying the same test file
- fix non-deterministic script name
- fix a minor bug, response not following the GraphQL spec (there's an extra `$out['data'][$operation_type]`)