### PR TITLE
Support list/nullable field types

### DIFF
--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -1,0 +1,84 @@
+namespace Slack\GraphQL\Codegen;
+
+use namespace HH\Lib\Str;
+use namespace Slack\GraphQL\Types;
+
+/**
+ * Examples:
+ *   int       -> IntInputType::nonNullable()
+ *   ?int      -> IntInputType::nullable()
+ *   ?vec<int> -> IntInputType::nonNullable()->nullableListOf()
+ */
+function input_type(string $hack_type): string {
+    list($unwrapped, $suffix) = unwrap_type($hack_type);
+    switch ($unwrapped) {
+        case 'HH\int':
+            $class = Types\IntInputType::class;
+            break;
+        case 'HH\string':
+            $class = Types\StringInputType::class;
+            break;
+        case 'HH\bool':
+            $class = Types\BooleanInputType::class;
+            break;
+        default:
+            invariant_violation('not yet implemented');
+    }
+    return Str\strip_prefix($class, 'Slack\\GraphQL\\').$suffix;
+}
+
+/**
+ * Same but for output types. By default, we ignore the nullability of the Hack type and force all GraphQL field return
+ * types to be nullable, so that we can return `null` as the field value in the GraphQL response in case of exceptions.
+ * TODO: Add a way to override this.
+ */
+function output_type(string $hack_type, bool $force_nullable = true): shape('type' => string, 'needs_await' => bool) {
+    $needs_await = false;
+    if (Str\starts_with($hack_type, 'HH\\Awaitable<')) {
+        $needs_await = true;
+        $hack_type = Str\strip_prefix($hack_type, 'HH\\Awaitable<') |> Str\strip_suffix($$, '>');
+    }
+
+    if ($force_nullable && !Str\starts_with($hack_type, '?')) {
+        $hack_type = '?'.$hack_type;
+    }
+
+    list($unwrapped, $suffix) = unwrap_type($hack_type);
+
+    switch ($unwrapped) {
+        case 'HH\int':
+            $class = Types\IntOutputType::class;
+            break;
+        case 'HH\string':
+            $class = Types\StringOutputType::class;
+            break;
+        case 'HH\bool':
+            $class = Types\BooleanOutputType::class;
+            break;
+        default:
+            $rc = new \ReflectionClass($unwrapped);
+            $graphql_object = $rc->getAttributeClass(\Slack\GraphQL\ObjectType::class) ??
+                $rc->getAttributeClass(\Slack\GraphQL\InterfaceType::class);
+            if ($graphql_object is null) {
+                throw new \Error(
+                    'GraphQL\Field return types must be scalar or be classes annnotated with <<GraphQL\ObjectType(...)>> or <<GraphQL\InterfaceType(...)>>',
+                );
+            }
+            $class = $graphql_object->getType();
+    }
+    return shape('type' => Str\strip_prefix($class, 'Slack\\GraphQL\\').$suffix, 'needs_await' => $needs_await);
+}
+
+/**
+ * Shared logic for the above.
+ */
+function unwrap_type(string $hack_type, bool $nullable = false): (string, string) {
+    if (Str\starts_with($hack_type, '?')) {
+        return unwrap_type(Str\strip_prefix($hack_type, '?'), true);
+    }
+    if (Str\starts_with($hack_type, 'HH\vec<')) {
+        list($unwrapped, $suffix) = unwrap_type(Str\strip_prefix($hack_type, 'HH\vec<') |> Str\strip_suffix($$, '>'));
+        return tuple($unwrapped, $suffix.($nullable ? '->nullableListOf()' : '->nonNullableListOf()'));
+    }
+    return tuple($hack_type, $nullable ? '::nullable()' : '::nonNullable()');
+}

--- a/src/playground/OutputTypeTestObj.hack
+++ b/src/playground/OutputTypeTestObj.hack
@@ -1,0 +1,52 @@
+use namespace Slack\GraphQL;
+
+<<GraphQL\ObjectType('OutputTypeTest', 'Test object for fields with various return types')>>
+final class OutputTypeTestObj {
+
+    <<GraphQL\QueryRootField('output_type_test', 'Root field to get an instance')>>
+    public static function get(): OutputTypeTestObj {
+        return new self();
+    }
+
+    <<GraphQL\Field(
+        'scalar',
+        'Note that the GraphQL field will be nullable by default, despite its non-nullable Hack type',
+    )>>
+    public function scalar(): int {
+        return 42;
+    }
+
+    <<GraphQL\Field('nullable', '')>>
+    public function nullable(): ?string {
+        return null;
+    }
+
+    <<GraphQL\Field('awaitable', '')>>
+    public async function awaitable(): Awaitable<int> {
+        return 42;
+    }
+
+    <<GraphQL\Field('awaitable_nullable', '')>>
+    public async function awaitable_nullable(): Awaitable<?string> {
+        return null;
+    }
+
+    <<GraphQL\Field('list', '')>>
+    public function list(): vec<string> {
+        return vec['forty', 'two'];
+    }
+
+    <<GraphQL\Field('awaitable_nullable_list', '')>>
+    public async function awaitable_nullable_list(): Awaitable<?vec<int>> {
+        return null;
+    }
+
+    <<GraphQL\Field('nested_lists', 'Note that nested lists can be non-nullable')>>
+    public function nested_lists(): vec<?vec<vec<?int>>> {
+        return vec[
+            vec[vec[null, 42]],
+            null,
+            vec[vec[42], vec[null]],
+        ];
+    }
+}

--- a/tests/OutputTypeTest.hack
+++ b/tests/OutputTypeTest.hack
@@ -1,0 +1,44 @@
+use function Facebook\FBExpect\expect;
+use namespace HH\Lib\C;
+use namespace Slack\GraphQL;
+
+/**
+ * Test GraphQL fields with various types.
+ */
+final class OutputTypeTest extends PlaygroundTest {
+
+    <<__Override>>
+    public static function getTestCases(): dict<string, (string, dict<string, mixed>, dict<string, mixed>)> {
+        return dict[
+            'all OutputTypeTestObj fields' => tuple(
+                'query {
+                    output_type_test {
+                        scalar
+                        nullable
+                        awaitable
+                        awaitable_nullable
+                        list
+                        awaitable_nullable_list
+                        nested_lists
+                    }
+                }',
+                dict[],
+                dict[
+                    'output_type_test' => dict[
+                        'scalar' => 42,
+                        'nullable' => null,
+                        'awaitable' => 42,
+                        'awaitable_nullable' => null,
+                        'list' => vec['forty', 'two'],
+                        'awaitable_nullable_list' => null,
+                        'nested_lists' => vec[
+                            vec[vec[null, 42]],
+                            null,
+                            vec[vec[42], vec[null]],
+                        ],
+                    ],
+                ],
+            ),
+        ];
+    }
+}

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -13,8 +13,8 @@ abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
 
     <<__Memoize>>
     private static async function runCodegenAsync(): Awaitable<void> {
-        $file = await GraphQL\Codegen\Generator::forFile(
-            __DIR__.'/../src/playground/Playground.hack',
+        $file = await GraphQL\Codegen\Generator::forPath(
+            __DIR__.'/../src/playground',
             shape(
                 'output_path' => __DIR__.'/gen/Generated.hack',
             ),

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<945571f40a6716a8089241b62efc534a>>
+ * @generated SignedSource<<1b33e2a23a3fde327e1a4706574d879d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -39,6 +39,11 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
     string $field_name,
   ): GraphQL\IFieldDefinition<this::THackType> {
     switch ($field_name) {
+      case 'output_type_test':
+        return new GraphQL\FieldDefinition(
+          OutputTypeTest::nullable(),
+          async ($parent, $args, $vars) ==> \OutputTypeTestObj::get(),
+        );
       case 'viewer':
         return new GraphQL\FieldDefinition(
           User::nullable(),
@@ -128,6 +133,56 @@ final class User extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           Types\BooleanOutputType::nullable(),
           async ($parent, $args, $vars) ==> $parent->isActive(),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
+final class OutputTypeTest extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \OutputTypeTestObj;
+  const NAME = 'OutputTypeTest';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'scalar':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->scalar(),
+        );
+      case 'nullable':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->nullable(),
+        );
+      case 'awaitable':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable(),
+          async ($parent, $args, $vars) ==> await $parent->awaitable(),
+        );
+      case 'awaitable_nullable':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> await $parent->awaitable_nullable(),
+        );
+      case 'list':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nonNullable()->nullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->list(),
+        );
+      case 'awaitable_nullable_list':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nonNullable()->nullableListOf(),
+          async ($parent, $args, $vars) ==> await $parent->awaitable_nullable_list(),
+        );
+      case 'nested_lists':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable()->nonNullableListOf()->nullableListOf()->nullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->nested_lists(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);


### PR DESCRIPTION
#29 implemented execution for list/non-nullable fields; this adds the ability to actually codegen fields with such types + a test.