### PR TITLE
error responses

### DIFF
--- a/src/FieldDefinition.hack
+++ b/src/FieldDefinition.hack
@@ -27,9 +27,9 @@ final class FieldDefinition<TParent, TRet> implements IFieldDefinition<TParent> 
         try {
             $value = await $resolver($parent, $field->getArguments() ?? dict[], $vars);
         } catch (UserFacingError $e) {
-            return new InvalidFieldResult(vec[$e]);
+            return $this->type->resolveError($e);
         } catch (\Throwable $e) {
-            return new InvalidFieldResult(vec[new FieldResolverError($e)]);
+            return $this->type->resolveError(new FieldResolverError($e));
         }
 
         return await $this->type->resolveAsync($value, $field, $vars);

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -1,34 +1,101 @@
 namespace Slack\GraphQL;
 
+use namespace HH\Lib\{C, Vec};
+
 final class Resolver {
+
+    /**
+     * @see https://spec.graphql.org/draft/#sec-Response
+     */
+    const type TResponse = shape(
+        ?'data' => mixed, // missing data and null data are both valid states with different meanings
+        ?'errors' => vec<shape( // errors are optional but cannot be null (or empty) if present
+            'message' => string,
+            ?'location' => shape('line' => int, 'column' => int),
+            ?'path' => vec<arraykey>,
+        )>,
+        ?'extensions' => dict<string, mixed>,
+    );
+
     public function __construct(private classname<BaseSchema> $schema) {}
 
+    /**
+     * Operation name must be specified if the GraphQL request contains multiple operations.
+     *
+     * @see https://spec.graphql.org/draft/#sec-Execution
+     */
     public async function resolve(
         \Graphpinator\Parser\ParsedRequest $request,
         ?dict<string, mixed> $variables = null,
-    ): Awaitable<shape(?'data' => mixed, ?'errors' => vec<string>)> {
+        ?string $operation_name = null,
+    ): Awaitable<this::TResponse> {
+        $ret = shape();
+        $errors = vec[];
+
+        try {
+            list($ret['data'], $errors) = await $this->resolveImpl($request, $variables, $operation_name);
+        } catch (UserFacingError $e) {
+            $errors = vec[$e];
+        } catch (\Throwable $e) {
+            // TODO: This shoud not happen; if it does, it's a bug in the GraphQL framework. Every exception should
+            // either be UserFacingError, or caught somewhere. However, we probably still want to catch arbitrary
+            // exceptions here just in case and return *some* reasonable response.
+            throw $e; // for now, so as to not break existing tests
+        }
+
+        if (!C\is_empty($errors)) {
+            $ret['errors'] = Vec\map(
+                $errors,
+                $e ==> {
+                    $out = shape('message' => $e->getMessage());
+                    $path = $e->getPath();
+                    if ($path is nonnull) {
+                        $out['path'] = $path;
+                    }
+                    return $out;
+                },
+            );
+            return $ret;
+        }
+        return $ret;
+    }
+
+    public async function resolveImpl(
+        \Graphpinator\Parser\ParsedRequest $request,
+        ?dict<string, mixed> $variables,
+        ?string $operation_name,
+    ): Awaitable<(mixed, vec<UserFacingError>)> {
         // TODO: validate variables against $schema
         $schema = $this->schema;
 
-        // TODO: what does the spec say should actually be contained in the output?
-        $out = shape('data' => dict[]);
-        foreach ($request->getOperations() as $operation) {
-            $operation_type = $operation->getType();
-            switch ($operation_type) {
-                case 'query':
-                    $data = await $schema::resolveQuery($operation, $variables ?? dict[]);
-                    break;
-                case 'mutation':
-                    invariant($schema::SUPPORTS_MUTATIONS, 'mutation operation not supported for schema');
-                    $data = await $schema::resolveMutation($operation, $variables ?? dict[]);
-                    break;
-                default:
-                    throw new \Error('Unsupported operation: '.$operation_type);
-            }
-
-            $out['data'] = $data->getValue();
+        if ($operation_name is nonnull) {
+            assert(
+                C\contains_key($request->getOperations(), $operation_name),
+                'Operation %s not found in the request',
+                $operation_name,
+            );
+            $operation = $request->getOperations()[$operation_name];
+        } else {
+            assert(
+                C\count($request->getOperations()) === 1,
+                'Operation name must be specified if the request contains multiple'
+            );
+            $operation = C\onlyx($request->getOperations());
         }
 
-        return $out;
+        $operation_type = $operation->getType();
+        switch ($operation_type) {
+            case 'query':
+                $result = await $schema::resolveQuery($operation, $variables ?? dict[]);
+                break;
+            case 'mutation':
+                invariant($schema::SUPPORTS_MUTATIONS, 'mutation operation not supported for schema');
+                $result = await $schema::resolveMutation($operation, $variables ?? dict[]);
+                break;
+            default:
+                throw new \Error('Unsupported operation: '.$operation_type);
+        }
+
+        return tuple($result->getValue(), $result->getErrors());
     }
 }

--- a/src/Types/Output/NullableOutputType.hack
+++ b/src/Types/Output/NullableOutputType.hack
@@ -32,4 +32,8 @@ final class NullableOutputType<TInner> extends OutputType<?TInner> {
             ? $result
             : new GraphQL\ValidFieldResult(null, $result->getErrors());
     }
+
+    public function resolveError(GraphQL\UserFacingError $error): GraphQL\ValidFieldResult {
+        return new GraphQL\ValidFieldResult(null, vec[$error]);
+    }
 }

--- a/src/Types/Output/OutputType.hack
+++ b/src/Types/Output/OutputType.hack
@@ -26,9 +26,20 @@ abstract class OutputType<TExpected> extends BaseType {
         return new NullableOutputType($this->nonNullableListOf());
     }
 
+    /**
+     * Convert a value returned by the field resolver into what should be put in the GraphQL response, possibly
+     * recursively.
+     */
     abstract public function resolveAsync(
         TExpected $value,
         \Graphpinator\Parser\Field\IHasFieldSet $field,
         GraphQL\__Private\Variables $vars,
     ): Awaitable<GraphQL\FieldResult>;
+
+    /**
+     * Convert an exception thrown by the field resolver into what should be put in the GraphQL response.
+     */
+    public function resolveError(GraphQL\UserFacingError $error): GraphQL\FieldResult {
+        return new GraphQL\InvalidFieldResult(vec[$error]);
+    }
 }

--- a/src/playground/ErrorTestObj.hack
+++ b/src/playground/ErrorTestObj.hack
@@ -1,0 +1,24 @@
+use namespace Slack\GraphQL;
+
+<<GraphQL\ObjectType('ErrorTest', 'Test object for error handling')>>
+final class ErrorTestObj {
+
+    <<GraphQL\QueryRootField('error_test', 'Root field to get an instance')>>
+    public static function get(): ErrorTestObj {
+        return new self();
+    }
+
+    <<GraphQL\Field('user_facing_error', '')>>
+    public function user_facing_error(): ?string {
+        throw new GraphQL\UserFacingError('You shall not pass!');
+    }
+
+    <<GraphQL\Field(
+        'hidden_exception',
+        'Arbitrary exceptions are hidden from clients, since they might contain sensitive data',
+    )>>
+    public function hidden_exception(): int {
+        // Contains a top secret IP address
+        throw new \Exception('Could not connect to database at 127.0.0.1');
+    }
+}

--- a/tests/BasicTest.hack
+++ b/tests/BasicTest.hack
@@ -5,7 +5,7 @@ use namespace Slack\GraphQL;
 final class BasicTest extends PlaygroundTest {
 
     <<__Override>>
-    public static function getTestCases(): dict<string, (string, dict<string, mixed>, dict<string, mixed>)> {
+    public static function getTestCases(): this::TTestCases {
         return dict[
             'select team.id' => tuple(
                 'query { viewer { id, team { id } } }',

--- a/tests/ErrorTest.hack
+++ b/tests/ErrorTest.hack
@@ -1,0 +1,32 @@
+use function Facebook\FBExpect\expect;
+
+final class ErrorTest extends PlaygroundTest {
+
+    <<__Override>>
+    public static function getTestCases(): this::TTestCases {
+        return dict[
+            'errors' => tuple(
+                'query { error_test { user_facing_error, hidden_exception } }',
+                dict[],
+                shape(
+                    'data' => dict[
+                        'error_test' => dict[
+                            'user_facing_error' => null,
+                            'hidden_exception' => null,
+                        ]
+                    ],
+                    'errors' => vec[
+                        shape(
+                            'message' => 'You shall not pass!',
+                            'path' => vec['error_test', 'user_facing_error'],
+                        ),
+                        shape(
+                            'message' => 'Caught exception while resolving field.',
+                            'path' => vec['error_test', 'hidden_exception'],
+                        ),
+                    ],
+                ),
+            ),
+        ];
+    }
+}

--- a/tests/OutputTypeTest.hack
+++ b/tests/OutputTypeTest.hack
@@ -8,7 +8,7 @@ use namespace Slack\GraphQL;
 final class OutputTypeTest extends PlaygroundTest {
 
     <<__Override>>
-    public static function getTestCases(): dict<string, (string, dict<string, mixed>, dict<string, mixed>)> {
+    public static function getTestCases(): this::TTestCases {
         return dict[
             'all OutputTypeTestObj fields' => tuple(
                 'query {

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -4,7 +4,9 @@ use namespace Slack\GraphQL;
 
 abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
 
-    abstract public static function getTestCases(): dict<string, (string, dict<string, mixed>, dict<string, mixed>)>;
+    const type TTestCases = dict<string, (string, dict<string, mixed>, mixed)>;
+
+    abstract public static function getTestCases(): this::TTestCases;
 
     <<__Override>>
     public static async function beforeFirstTestAsync(): Awaitable<void> {
@@ -28,9 +30,13 @@ abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
     final public async function test(
         string $query,
         dict<string, mixed> $variables,
-        dict<string, mixed> $expected_response,
+        mixed $expected_response,
     ): Awaitable<void> {
-        if (!C\contains_key($expected_response, 'data')) {
+        // If $expected_response is not a shape with 'data' and/or 'errors', assume it's the data.
+        if (
+            !$expected_response is shape('data' => mixed, ...) &&
+            !$expected_response is shape('errors' => mixed, ...)
+        ) {
             $expected_response = shape('data' => $expected_response);
         }
 

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c3144e23b8a885fa0842720d2d926d74>>
+ * @generated SignedSource<<4076197cabac0f42468f43874c01e2cb>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -39,6 +39,11 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
     string $field_name,
   ): GraphQL\IFieldDefinition<this::THackType> {
     switch ($field_name) {
+      case 'error_test':
+        return new GraphQL\FieldDefinition(
+          ErrorTest::nullable(),
+          async ($parent, $args, $vars) ==> \ErrorTestObj::get(),
+        );
       case 'output_type_test':
         return new GraphQL\FieldDefinition(
           OutputTypeTest::nullable(),
@@ -133,6 +138,31 @@ final class User extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           Types\BooleanOutputType::nullable(),
           async ($parent, $args, $vars) ==> $parent->isActive(),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
+final class ErrorTest extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \ErrorTestObj;
+  const NAME = 'ErrorTest';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'user_facing_error':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->user_facing_error(),
+        );
+      case 'hidden_exception':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->hidden_exception(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);


### PR DESCRIPTION
Transforms `UserFacingError`s into the correct format per the official GraphQL spec.