### PR TITLE
non-nullable fields + errors

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -144,7 +144,10 @@ class Field {
         $hb->addLine('return new GraphQL\\FieldDefinition(')->indent();
 
         // Field return type
-        $type_info = output_type($this->reflection_method->getReturnTypeText());
+        $type_info = output_type(
+            $this->reflection_method->getReturnTypeText(),
+            $this->reflection_method->getAttributeClass(\Slack\GraphQL\KillsParentOnException::class) is nonnull,
+        );
         $hb->addLinef('%s,', $type_info['type']);
 
         // Arguments

--- a/src/Field.hack
+++ b/src/Field.hack
@@ -7,3 +7,26 @@ class Field implements \HH\MethodAttribute {
         return $this->name;
     }
 }
+
+/**
+ * Must be used in combination with GraphQL\Field, on a method with a non-nullable return type in Hack. If present, the
+ * field will be surfaced to GraphQL clients as *non-nullable* (without this, even methods with a non-nullable Hack
+ * return type are surfaced as *nullable* GraphQL fields).
+ *
+ * This has the effect that if the Hack method throws an exception, instead of returning `null` as the field value, the
+ * exception is propagated to be handled by the parent field. If the parent field is nullable, then it resolves to null,
+ * otherwise the exception is further propagated to its parent field, possibly all the way up to the query root (the
+ * 'data' field will be null in the GraphQL response).
+ *
+ * Non-nullable fields are useful because they allow clients to avoid null checks on every GraphQL field; but also
+ * potentially dangerous because they can cause a large part of the response, or even the whole response, to be thrown
+ * away because of a single field that failed to resolve.
+ *
+ * It's generally safe to use this on Hack methods that are guaranteed to never throw exceptions, but unfortunately Hack
+ * provides no way to enforce such contract, so it might still be risky if the method's code changes in the future.
+ *
+ * @see https://spec.graphql.org/draft/#sec-Handling-Field-Errors
+ */
+final class KillsParentOnException implements \HH\MethodAttribute {
+    public function __construct() {}
+}

--- a/src/playground/ErrorTestObj.hack
+++ b/src/playground/ErrorTestObj.hack
@@ -8,6 +8,19 @@ final class ErrorTestObj {
         return new self();
     }
 
+    <<
+        GraphQL\QueryRootField('error_test_nn', 'A non-nullable root field to get an instance'),
+        GraphQL\KillsParentOnException,
+    >>
+    public static function getNonNullable(): ErrorTestObj {
+        return new self();
+    }
+
+    <<GraphQL\Field('no_error', '')>>
+    public function no_error(): int {
+        return 42;
+    }
+
     <<GraphQL\Field('user_facing_error', '')>>
     public function user_facing_error(): ?string {
         throw new GraphQL\UserFacingError('You shall not pass!');
@@ -20,5 +33,59 @@ final class ErrorTestObj {
     public function hidden_exception(): int {
         // Contains a top secret IP address
         throw new \Exception('Could not connect to database at 127.0.0.1');
+    }
+
+    <<GraphQL\Field('non_nullable', ''), GraphQL\KillsParentOnException>>
+    public function non_nullable(): int {
+        throw new GraphQL\UserFacingError('You shall not pass!');
+    }
+
+    <<GraphQL\Field('nested', '')>>
+    public function nested(): ErrorTestObj {
+        return new self();
+    }
+
+    <<GraphQL\Field('nested_nn', ''), GraphQL\KillsParentOnException>>
+    public function nested_nn(): ErrorTestObj {
+        return new self();
+    }
+
+    /**
+     * Lists with an invalid Int value.
+     */
+    <<GraphQL\Field('bad_int_list_n_of_n', '')>>
+    public function bad_int_list_n_of_n(): vec<?int> {
+        return $this->bad_int_list_nn_of_nn();
+    }
+
+    <<GraphQL\Field(
+        'bad_int_list_n_of_nn',
+        'Nullability of nested types is respected, which may result in killing the whole list (but no parents)',
+    )>>
+    public function bad_int_list_n_of_nn(): vec<int> {
+        return $this->bad_int_list_nn_of_nn();
+    }
+
+    <<GraphQL\Field('bad_int_list_nn_of_nn', ''), GraphQL\KillsParentOnException>>
+    public function bad_int_list_nn_of_nn(): vec<int> {
+        return vec[1, 2, GraphQL\Types\IntOutputType::MAX_SAFE_VALUE + 42, 3, 4];
+    }
+
+    /**
+     * Lists of self. These may be killed by their non-nullable children.
+     */
+    <<GraphQL\Field('nested_list_n_of_n', '')>>
+    public function nested_list_n_of_n(): vec<?ErrorTestObj> {
+        return $this->nested_list_nn_of_nn();
+    }
+
+    <<GraphQL\Field('nested_list_n_of_nn', '')>>
+    public function nested_list_n_of_nn(): vec<ErrorTestObj> {
+        return $this->nested_list_nn_of_nn();
+    }
+
+    <<GraphQL\Field('nested_list_nn_of_nn', ''), GraphQL\KillsParentOnException>>
+    public function nested_list_nn_of_nn(): vec<ErrorTestObj> {
+        return vec[new self(), new self()];
     }
 }

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<4076197cabac0f42468f43874c01e2cb>>
+ * @generated SignedSource<<4a258ae7c1b6949e15ddb40c2ab4287c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -43,6 +43,11 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           ErrorTest::nullable(),
           async ($parent, $args, $vars) ==> \ErrorTestObj::get(),
+        );
+      case 'error_test_nn':
+        return new GraphQL\FieldDefinition(
+          ErrorTest::nonNullable(),
+          async ($parent, $args, $vars) ==> \ErrorTestObj::getNonNullable(),
         );
       case 'output_type_test':
         return new GraphQL\FieldDefinition(
@@ -154,6 +159,11 @@ final class ErrorTest extends \Slack\GraphQL\Types\ObjectType {
     string $field_name,
   ): GraphQL\IFieldDefinition<this::THackType> {
     switch ($field_name) {
+      case 'no_error':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->no_error(),
+        );
       case 'user_facing_error':
         return new GraphQL\FieldDefinition(
           Types\StringOutputType::nullable(),
@@ -163,6 +173,51 @@ final class ErrorTest extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           Types\IntOutputType::nullable(),
           async ($parent, $args, $vars) ==> $parent->hidden_exception(),
+        );
+      case 'non_nullable':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nonNullable(),
+          async ($parent, $args, $vars) ==> $parent->non_nullable(),
+        );
+      case 'nested':
+        return new GraphQL\FieldDefinition(
+          ErrorTest::nullable(),
+          async ($parent, $args, $vars) ==> $parent->nested(),
+        );
+      case 'nested_nn':
+        return new GraphQL\FieldDefinition(
+          ErrorTest::nonNullable(),
+          async ($parent, $args, $vars) ==> $parent->nested_nn(),
+        );
+      case 'bad_int_list_n_of_n':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable()->nullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->bad_int_list_n_of_n(),
+        );
+      case 'bad_int_list_n_of_nn':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nonNullable()->nullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->bad_int_list_n_of_nn(),
+        );
+      case 'bad_int_list_nn_of_nn':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nonNullable()->nonNullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->bad_int_list_nn_of_nn(),
+        );
+      case 'nested_list_n_of_n':
+        return new GraphQL\FieldDefinition(
+          ErrorTest::nullable()->nullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->nested_list_n_of_n(),
+        );
+      case 'nested_list_n_of_nn':
+        return new GraphQL\FieldDefinition(
+          ErrorTest::nonNullable()->nullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->nested_list_n_of_nn(),
+        );
+      case 'nested_list_nn_of_nn':
+        return new GraphQL\FieldDefinition(
+          ErrorTest::nonNullable()->nonNullableListOf(),
+          async ($parent, $args, $vars) ==> $parent->nested_list_nn_of_nn(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);


### PR DESCRIPTION
Adds codegen support for non-nullable fields (using the new attribute `KillsParentOnException` -- see its docblock for explanation) and a bunch of test cases. The test cases are actually the important part here (I wanted to ensure that error handling is implemented correctly), the support for non-nullable fields is secondary (it was impossible to write the tests without it) and I wouldn't necessarily recommend using them.

That said, non-nullable fields *do* have advantages (mainly, clients don't need as many null checks everywhere, which client developers like a lot), so maybe we shouldn't discourage them as much.

At FB, we heavily discourage non-nullable fields, but that is mostly for historical reasons and not necessarily the right call everywhere.

If you decide that non-nullable fields are fine, I'd recommend renaming `KillsParentOnException` to something less scary, possibly just `NonNullable`.