### PR TITLE
Add support for `GraphQL\InputType` attribute

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -130,10 +130,10 @@ class InterfaceType extends CompositeType<\Slack\GraphQL\InterfaceType> {}
 
 class ObjectType extends CompositeType<\Slack\GraphQL\ObjectType> {}
 
-class InputType implements GeneratableClass {
+class InputObjectType implements GeneratableClass {
     public function __construct(
         private \ReflectionTypeAlias $reflection_type_alias,
-        private \Slack\GraphQL\InputType $input_type,
+        private \Slack\GraphQL\InputObjectType $input_type,
     ) {}
 
     public function getType(): string {
@@ -343,7 +343,7 @@ final class Generator {
                 ->setIsFinal(true);
             $file->addClass($class);
 
-            if ($object is InputType) {
+            if ($object is InputObjectType) {
                 $has_type_assertions = true;
             }
         }
@@ -425,10 +425,10 @@ final class Generator {
         $input_types = $this->parser->getTypes();
         foreach ($input_types as $type) {
             $rt = new \ReflectionTypeAlias($type->getName());
-            $graphql_input = $rt->getAttributeClass(\Slack\GraphQL\InputType::class);
+            $graphql_input = $rt->getAttributeClass(\Slack\GraphQL\InputObjectType::class);
             if ($graphql_input is null) continue;
 
-            $inputs[] = new InputType($rt, $graphql_input);
+            $inputs[] = new InputObjectType($rt, $graphql_input);
         }
 
         $interface_types = $this->parser->getInterfaces() |> Vec\concat($$, $this->parser->getClasses());

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -234,10 +234,6 @@ class Field {
 
     protected function getArgumentInvocationStrings(): vec<string> {
         $invocations = vec[];
-        // do we need to know about all inputs here? i think we need to generate
-        // a type for each input type so we can define coerceNode that
-        // references the type name as a generic so we can assert the type
-        // structure
         foreach ($this->reflection_method->getParameters() as $index => $param) {
             $invocations[] = Str\format(
                 '%s->coerceNode($args[%s]->getValue(), $vars)',

--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -25,7 +25,7 @@ function input_type(string $hack_type): string {
             $class = get_input_class($unwrapped);
             if ($class is null) {
                 throw new \Error(
-                    'GraphQL\Field argument types must be scalar or be enums annnotated with a GraphQL attribute'
+                    'GraphQL\Field argument types must be scalar or be enums annnotated with a GraphQL attribute',
                 );
             }
     }
@@ -87,10 +87,20 @@ function get_input_class(string $hack_type): ?string {
     try {
         $rc = new \ReflectionClass($hack_type);
         $graphql_enum = $rc->getAttributeClass(\Slack\GraphQL\EnumType::class);
-        if ($graphql_enum) {
+        if ($graphql_enum is nonnull) {
             return $graphql_enum->getInputType();
         }
-    } catch (\ReflectionException $_e) {}
+    } catch (\ReflectionException $_e) {
+    }
+
+    try {
+        $rt = new \ReflectionTypeAlias($hack_type);
+        $graphql_input = $rt->getAttributeClass(\Slack\GraphQL\InputType::class);
+        if ($graphql_input is nonnull) {
+            return $graphql_input->getType();
+        }
+    } catch (\ReflectionException $_e) {
+    }
 
     return null;
 }

--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -73,7 +73,7 @@ function output_type(
             $class = get_output_class($unwrapped);
             if ($class is null) {
                 throw new \Error(
-                    'GraphQL\Field return types must be scalar or be classes annnotated with a GraphQL attribute'
+                    'GraphQL\Field return types must be scalar or be classes annnotated with a GraphQL attribute',
                 );
             }
     }

--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -95,7 +95,7 @@ function get_input_class(string $hack_type): ?string {
 
     try {
         $rt = new \ReflectionTypeAlias($hack_type);
-        $graphql_input = $rt->getAttributeClass(\Slack\GraphQL\InputType::class);
+        $graphql_input = $rt->getAttributeClass(\Slack\GraphQL\InputObjectType::class);
         if ($graphql_input is nonnull) {
             return $graphql_input->getType();
         }

--- a/src/InputType.hack
+++ b/src/InputType.hack
@@ -6,7 +6,7 @@ namespace Slack\GraphQL;
 * Annotate shapes with this attribute to support accepting them as inputs within
 * mutations.
 */
-class InputType implements \HH\TypeAliasAttribute {
+class InputObjectType implements \HH\TypeAliasAttribute {
     public function __construct(private string $type, private string $description) {}
 
     public function getType(): string {

--- a/src/InputType.hack
+++ b/src/InputType.hack
@@ -1,0 +1,15 @@
+namespace Slack\GraphQL;
+
+/**
+* GraphQL input type: https://graphql.org/learn/schema/#input-types
+*
+* Annotate shapes with this attribute to support accepting them as inputs within
+* mutations.
+*/
+class InputType implements \HH\TypeAliasAttribute {
+    public function __construct(private string $type, private string $description) {}
+
+    public function getType(): string {
+        return $this->type;
+    }
+}

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -78,7 +78,7 @@ final class Resolver {
         } else {
             \Slack\GraphQL\assert(
                 C\count($request->getOperations()) === 1,
-                'Operation name must be specified if the request contains multiple'
+                'Operation name must be specified if the request contains multiple',
             );
             $operation = C\onlyx($request->getOperations());
         }

--- a/src/Types/Input/InputObjectType.hack
+++ b/src/Types/Input/InputObjectType.hack
@@ -1,0 +1,37 @@
+namespace Slack\GraphQL\Types;
+
+use namespace Facebook\{TypeCoerce, TypeAssert};
+
+<<__ConsistentConstruct>>
+abstract class InputObjectType<TCoerced as nonnull> extends InputType<TCoerced> {
+
+    abstract const string NAME;
+    abstract public function coerceValue(mixed $value): TCoerced;
+    abstract public function assertValidVariableValue(mixed $value): TCoerced;
+
+    <<__Override>>
+    final public function getName(): string {
+        return static::NAME;
+    }
+
+    <<__Override>>
+    final public function coerceNonVariableNode(
+        \Graphpinator\Parser\Value\Value $node,
+        dict<string, mixed> $variable_values,
+    ): TCoerced {
+        return $this->coerceValue($node->getRawValue());
+    }
+
+    /**
+     * Use these to get the singleton instance of this type.
+     */
+    <<__MemoizeLSB>>
+    final public static function nonNullable(): this {
+        return new static();
+    }
+
+    <<__MemoizeLSB>>
+    final public static function nullable(): \Slack\GraphQL\Types\NullableInputType<TCoerced> {
+        return new \Slack\GraphQL\Types\NullableInputType(static::nonNullable());
+    }
+}

--- a/src/Types/Input/InputType.hack
+++ b/src/Types/Input/InputType.hack
@@ -23,10 +23,7 @@ abstract class InputType<TCoerced> extends BaseType {
      * Variable values are assumed to have already been validated/coerced (this is important because coercion is not
      * always idempotent).
      */
-    final public function coerceNode(
-        Value\Value $node,
-        dict<string, mixed> $variable_values,
-    ): TCoerced {
+    final public function coerceNode(Value\Value $node, dict<string, mixed> $variable_values): TCoerced {
         return $node is Value\VariableRef
             ? $this->assertValidVariableValue($variable_values[$node->getVarName()])
             : $this->coerceNonVariableNode($node, $variable_values);

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -40,12 +40,12 @@ query {
 use namespace Slack\GraphQL;
 use namespace HH\Lib\{Math, Vec};
 
-<<GraphQL\InputType('CreateTeamInput', 'Arguments for creating a team')>>
+<<GraphQL\InputObjectType('CreateTeamInput', 'Arguments for creating a team')>>
 type TCreateTeamInput = shape(
     'name' => string,
 );
 
-<<GraphQL\InputType('CreateUserInput', 'Arguments for creating a user')>>
+<<GraphQL\InputObjectType('CreateUserInput', 'Arguments for creating a user')>>
 type TCreateUserInput = shape(
     'name' => string,
     ?'is_active' => bool,

--- a/tests/InputTypeTest.hack
+++ b/tests/InputTypeTest.hack
@@ -1,0 +1,88 @@
+use function Facebook\FBExpect\expect;
+use namespace HH\Lib\C;
+use namespace Slack\GraphQL;
+
+/**
+* Test GraphQL mutations with input types.
+*/
+final class InputTypeTest extends PlaygroundTest {
+    <<__Override>>
+    public static function getTestCases(): this::TTestCases {
+        return dict[
+            "simple input type, don't provide field with default" => tuple(
+                'mutation CreateUser($input: CreateUserInput!) {
+                    createUser(input: $input) {
+                        id
+                        is_active
+                        name
+                    }
+                }',
+                dict[
+                    'input' => dict[
+                        'name' => 'New User',
+                    ],
+                ],
+                dict[
+                    'createUser' => dict[
+                        'id' => 3,
+                        'name' => 'New User',
+                        'is_active' => true,
+                    ],
+                ],
+            ),
+            "simple input type, provide field with default" => tuple(
+                'mutation CreateUser($input: CreateUserInput!) {
+                    createUser(input: $input) {
+                        id
+                        is_active
+                        name
+                    }
+                }',
+                dict[
+                    'input' => dict[
+                        'name' => 'New User',
+                        'is_active' => false,
+                    ],
+                ],
+                dict[
+                    'createUser' => dict[
+                        'id' => 3,
+                        'name' => 'New User',
+                        'is_active' => false,
+                    ],
+                ],
+            ),
+            "complex input type" => tuple(
+                'mutation CreateUser($input: CreateUserInput!) {
+                    createUser(input: $input) {
+                        id
+                        is_active
+                        name
+                        team {
+                            name
+                        }
+                    }
+                }',
+                dict[
+                    'input' => dict[
+                        'name' => 'New User',
+                        'team' => dict[
+                            'name' => 'New Team',
+                        ],
+                    ],
+                ],
+                dict[
+                    'createUser' => dict[
+                        'id' => 3,
+                        'name' => 'New User',
+                        'is_active' => true,
+                        'team' => dict[
+                            'name' => 'New Team',
+                        ],
+                    ],
+                ],
+            ),
+        ];
+    }
+
+}

--- a/tests/InputTypeTest.hack
+++ b/tests/InputTypeTest.hack
@@ -15,6 +15,9 @@ final class InputTypeTest extends PlaygroundTest {
                         id
                         is_active
                         name
+                        team {
+                            name
+                        }
                     }
                 }',
                 dict[
@@ -27,6 +30,9 @@ final class InputTypeTest extends PlaygroundTest {
                         'id' => 3,
                         'name' => 'New User',
                         'is_active' => true,
+                        'team' => dict[
+                            'name' => 'Test Team 1',
+                        ],
                     ],
                 ],
             ),
@@ -36,6 +42,9 @@ final class InputTypeTest extends PlaygroundTest {
                         id
                         is_active
                         name
+                        team {
+                            name
+                        }
                     }
                 }',
                 dict[
@@ -49,6 +58,9 @@ final class InputTypeTest extends PlaygroundTest {
                         'id' => 3,
                         'name' => 'New User',
                         'is_active' => false,
+                        'team' => dict[
+                            'name' => 'Test Team 1',
+                        ],
                     ],
                 ],
             ),

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -34,8 +34,7 @@ abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
     ): Awaitable<void> {
         // If $expected_response is not a shape with 'data' and/or 'errors', assume it's the data.
         if (
-            !$expected_response is shape('data' => mixed, ...) &&
-            !$expected_response is shape('errors' => mixed, ...)
+            !$expected_response is shape('data' => mixed, ...) && !$expected_response is shape('errors' => mixed, ...)
         ) {
             $expected_response = shape('data' => $expected_response);
         }
@@ -47,6 +46,6 @@ abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
         $resolver = new GraphQL\Resolver(\Slack\GraphQL\Test\Generated\Schema::class);
 
         $out = await $resolver->resolve($request, $variables);
-        expect($out)->toEqual($expected_response);
+        expect($out)->toHaveSameShapeAs($expected_response);
     }
 }

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,12 +4,14 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<3ea39fd909ead378947c19291e4a19c2>>
+ * @generated SignedSource<<0fbb7f9ad91541e4e77ea10eb7096fcf>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
 use namespace HH\Lib\Dict;
+use namespace Facebook\TypeAssert;
+use namespace Facebook\TypeCoerce;
 
 abstract final class Schema extends \Slack\GraphQL\BaseSchema {
 
@@ -114,6 +116,13 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
           User::nullable(),
           async ($parent, $args, $vars) ==> await \UserMutationAttributes::pokeUser(
             Types\IntInputType::nonNullable()->coerceNode($args['id']->getValue(), $vars),
+          ),
+        );
+      case 'createUser':
+        return new GraphQL\FieldDefinition(
+          User::nullable(),
+          async ($parent, $args, $vars) ==> await \UserMutationAttributes::createUser(
+            CreateUserInput::nonNullable()->coerceNode($args['input']->getValue(), $vars),
           ),
         );
       default:
@@ -412,4 +421,40 @@ final class FavoriteColorOutputType
   const NAME = 'FavoriteColor';
   const type THackType = \FavoriteColor;
   const \HH\enumname<this::THackType> HACK_ENUM = \FavoriteColor::class;
+}
+
+final class CreateTeamInput
+  extends \Slack\GraphQL\Types\InputObjectType<\TCreateTeamInput> {
+
+  const NAME = 'CreateTeamInput';
+
+  <<__Override>>
+  final public function coerceValue(mixed $value): \TCreateTeamInput {
+    return TypeCoerce\match_type_structure(\HH\type_structure_for_alias(\TCreateTeamInput::class), $value);;
+  }
+
+  <<__Override>>
+  final public function assertValidVariableValue(
+    mixed $value,
+  ): \TCreateTeamInput {
+    return TypeAssert\matches_type_structure(\HH\type_structure_for_alias(\TCreateTeamInput::class), $value);;
+  }
+}
+
+final class CreateUserInput
+  extends \Slack\GraphQL\Types\InputObjectType<\TCreateUserInput> {
+
+  const NAME = 'CreateUserInput';
+
+  <<__Override>>
+  final public function coerceValue(mixed $value): \TCreateUserInput {
+    return TypeCoerce\match_type_structure(\HH\type_structure_for_alias(\TCreateUserInput::class), $value);;
+  }
+
+  <<__Override>>
+  final public function assertValidVariableValue(
+    mixed $value,
+  ): \TCreateUserInput {
+    return TypeAssert\matches_type_structure(\HH\type_structure_for_alias(\TCreateUserInput::class), $value);;
+  }
 }


### PR DESCRIPTION
Allows tagging of shapes with `<<GraphQL\InputType>>` to support accepting those shapes as input. GraphQL spec: https://graphql.org/learn/schema/#input-types.

> The fields on an input object type can themselves refer to input object types, but you can't mix input and output types in your schema. Input object types also can't have arguments on their fields.

I didn't add any checks for this yet.

One other note, this requires type assertion to verify the incoming dict coerces to the defined type. Not sure if there is a better way to do this.