### PR TITLE
add generics to FieldResult

### DIFF
--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -7,7 +7,7 @@ abstract class BaseSchema {
     abstract public static function resolveQuery(
         \Graphpinator\Parser\Operation\Operation $operation,
         __Private\Variables $variables,
-    ): Awaitable<ValidFieldResult>;
+    ): Awaitable<ValidFieldResult<?dict<string, mixed>>>;
 
     /**
     * Mutations are optional, if the schema supports it, this method will be
@@ -16,7 +16,7 @@ abstract class BaseSchema {
     public static async function resolveMutation(
         \Graphpinator\Parser\Operation\Operation $operation,
         __Private\Variables $variables,
-    ): Awaitable<ValidFieldResult> {
+    ): Awaitable<ValidFieldResult<?dict<string, mixed>>> {
         return new ValidFieldResult(null);
     }
 }

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -404,7 +404,7 @@ final class Generator {
             ->setPublic()
             ->setIsStatic(true)
             ->setIsAsync(true)
-            ->setReturnType('Awaitable<GraphQL\\ValidFieldResult>')
+            ->setReturnType('Awaitable<GraphQL\\ValidFieldResult<?dict<string, mixed>>>')
             ->addParameterf('\%s $operation', \Graphpinator\Parser\Operation\Operation::class)
             ->addParameterf('\%s $variables', \Slack\GraphQL\__Private\Variables::class);
 

--- a/src/FieldDefinition.hack
+++ b/src/FieldDefinition.hack
@@ -5,12 +5,12 @@ interface IFieldDefinition<TParent> {
         TParent $parent,
         \Graphpinator\Parser\Field\Field $field,
         __Private\Variables $vars,
-    ): Awaitable<FieldResult>;
+    ): Awaitable<FieldResult<mixed>>;
 }
 
-final class FieldDefinition<TParent, TRet> implements IFieldDefinition<TParent> {
+final class FieldDefinition<TParent, TRet, TResolved> implements IFieldDefinition<TParent> {
     public function __construct(
-        private Types\OutputType<TRet> $type,
+        private Types\OutputType<TRet, TResolved> $type,
         private (function(
             TParent,
             dict<string, \Graphpinator\Parser\Value\ArgumentValue>,
@@ -22,7 +22,7 @@ final class FieldDefinition<TParent, TRet> implements IFieldDefinition<TParent> 
         TParent $parent,
         \Graphpinator\Parser\Field\Field $field,
         __Private\Variables $vars,
-    ): Awaitable<FieldResult> {
+    ): Awaitable<FieldResult<TResolved>> {
         $resolver = $this->resolver;
         try {
             $value = await $resolver($parent, $field->getArguments() ?? dict[], $vars);

--- a/src/FieldResult.hack
+++ b/src/FieldResult.hack
@@ -4,7 +4,7 @@ namespace Slack\GraphQL;
  * These classes capture the possible results of resolving a GraphQL field during GraphQL execution.
  */
 <<__Sealed(InvalidFieldResult::class, ValidFieldResult::class)>>
-abstract class FieldResult {
+abstract class FieldResult<+T> {
     public function __construct(private vec<UserFacingError> $errors) {}
 
     final public function getErrors(): vec<UserFacingError> {
@@ -20,15 +20,15 @@ abstract class FieldResult {
  * - non-null value with error, if this object/list field is OK but has 1 or more nullable children with errors
  * - null value with error, if this is a nullable field that failed to resolve
  */
-final class ValidFieldResult extends FieldResult {
+final class ValidFieldResult<+T> extends FieldResult<T> {
     public function __construct(
-        private mixed $value,
+        private T $value,
         vec<UserFacingError> $errors = vec[],
     ) {
         parent::__construct($errors);
     }
 
-    public function getValue(): mixed {
+    public function getValue(): T {
         return $this->value;
     }
 }
@@ -38,5 +38,5 @@ final class ValidFieldResult extends FieldResult {
  * The error needs to be propagated to the closest parent nullable field, at which point a ValidFieldResult will be
  * returned, with null value and the same error.
  */
-final class InvalidFieldResult extends FieldResult {
+final class InvalidFieldResult extends FieldResult<nothing> {
 }

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -8,7 +8,7 @@ final class Resolver {
      * @see https://spec.graphql.org/draft/#sec-Response
      */
     const type TResponse = shape(
-        ?'data' => mixed, // missing data and null data are both valid states with different meanings
+        ?'data' => ?dict<string, mixed>, // missing data and null data are both valid states with different meanings
         ?'errors' => vec<shape( // errors are optional but cannot be null (or empty) if present
             'message' => string,
             ?'location' => shape('line' => int, 'column' => int),
@@ -64,7 +64,7 @@ final class Resolver {
         \Graphpinator\Parser\ParsedRequest $request,
         ?dict<string, mixed> $variables,
         ?string $operation_name,
-    ): Awaitable<(mixed, vec<UserFacingError>)> {
+    ): Awaitable<(?dict<string, mixed>, vec<UserFacingError>)> {
         // TODO: validate variables against $schema
         $schema = $this->schema;
 

--- a/src/Types/Output/LeafType.hack
+++ b/src/Types/Output/LeafType.hack
@@ -15,7 +15,7 @@ abstract class LeafType extends NamedOutputType {
         this::THackType $value,
         \Graphpinator\Parser\Field\IHasFieldSet $field,
         GraphQL\__Private\Variables $vars,
-    ): Awaitable<GraphQL\FieldResult> {
+    ): Awaitable<GraphQL\FieldResult<this::TCoerced>> {
         try {
             return new GraphQL\ValidFieldResult($this->coerce($value));
         } catch (GraphQL\UserFacingError $e) {

--- a/src/Types/Output/ListOutputType.hack
+++ b/src/Types/Output/ListOutputType.hack
@@ -3,16 +3,16 @@ namespace Slack\GraphQL\Types;
 use namespace HH\Lib\Vec;
 use namespace Slack\GraphQL;
 
-final class ListOutputType<TInner> extends OutputType<vec<TInner>> {
+final class ListOutputType<TInner, TResolved> extends OutputType<vec<TInner>, vec<mixed>> {
 
-    public function __construct(private OutputType<TInner> $innerType) {}
+    public function __construct(private OutputType<TInner, TResolved> $innerType) {}
 
     <<__Override>>
     public function getName(): ?string {
         return null;
     }
 
-    public function getInnerType(): OutputType<TInner> {
+    public function getInnerType(): OutputType<TInner, TResolved> {
         return $this->innerType;
     }
 
@@ -21,7 +21,7 @@ final class ListOutputType<TInner> extends OutputType<vec<TInner>> {
         vec<TInner> $value,
         \Graphpinator\Parser\Field\IHasFieldSet $field,
         GraphQL\__Private\Variables $vars,
-    ): Awaitable<GraphQL\FieldResult> {
+    ): Awaitable<GraphQL\FieldResult<vec<mixed>>> {
         $ret = vec[];
         $errors = vec[];
         $is_valid = true;
@@ -32,7 +32,7 @@ final class ListOutputType<TInner> extends OutputType<vec<TInner>> {
         );
 
         foreach ($results as $idx => $result) {
-            if ($result is GraphQL\ValidFieldResult) {
+            if ($result is GraphQL\ValidFieldResult<_>) {
                 $ret[] = $result->getValue();
             } else {
                 $is_valid = false;

--- a/src/Types/Output/NamedOutputType.hack
+++ b/src/Types/Output/NamedOutputType.hack
@@ -9,10 +9,11 @@ namespace Slack\GraphQL\Types;
  * @see https://spec.graphql.org/draft/#sec-Wrapping-Types
  */
 <<__ConsistentConstruct>>
-abstract class NamedOutputType extends OutputType<this::THackType> {
+abstract class NamedOutputType extends OutputType<this::THackType, this::TCoerced> {
 
     <<__Enforceable>>
     abstract const type THackType;
+    abstract const type TCoerced;
     abstract const string NAME;
 
     <<__Override>>
@@ -29,7 +30,7 @@ abstract class NamedOutputType extends OutputType<this::THackType> {
     }
 
     <<__MemoizeLSB>>
-    final public static function nullable(): NullableOutputType<this::THackType> {
+    final public static function nullable(): NullableOutputType<this::THackType, this::TCoerced> {
         return new NullableOutputType(static::nonNullable());
     }
 }

--- a/src/Types/Output/NullableOutputType.hack
+++ b/src/Types/Output/NullableOutputType.hack
@@ -1,16 +1,16 @@
 namespace Slack\GraphQL\Types;
 use namespace Slack\GraphQL;
 
-final class NullableOutputType<TInner> extends OutputType<?TInner> {
+final class NullableOutputType<TInner, TResolved> extends OutputType<?TInner, ?TResolved> {
 
-    public function __construct(private OutputType<TInner> $innerType) {}
+    public function __construct(private OutputType<TInner, TResolved> $innerType) {}
 
     <<__Override>>
     public function getName(): ?string {
         return null;
     }
 
-    public function getInnerType(): OutputType<TInner> {
+    public function getInnerType(): OutputType<TInner, TResolved> {
         return $this->innerType;
     }
 
@@ -23,17 +23,17 @@ final class NullableOutputType<TInner> extends OutputType<?TInner> {
         ?TInner $value,
         \Graphpinator\Parser\Field\IHasFieldSet $field,
         GraphQL\__Private\Variables $vars,
-    ): Awaitable<GraphQL\ValidFieldResult> {
+    ): Awaitable<GraphQL\ValidFieldResult<?TResolved>> {
         if ($value is null) {
             return new GraphQL\ValidFieldResult(null);
         }
         $result = await $this->innerType->resolveAsync($value, $field, $vars);
-        return $result is GraphQL\ValidFieldResult
+        return $result is GraphQL\ValidFieldResult<_>
             ? $result
             : new GraphQL\ValidFieldResult(null, $result->getErrors());
     }
 
-    public function resolveError(GraphQL\UserFacingError $error): GraphQL\ValidFieldResult {
+    public function resolveError(GraphQL\UserFacingError $error): GraphQL\ValidFieldResult<null> {
         return new GraphQL\ValidFieldResult(null, vec[$error]);
     }
 }

--- a/src/Types/Output/ObjectType.hack
+++ b/src/Types/Output/ObjectType.hack
@@ -4,6 +4,7 @@ use namespace HH\Lib\Dict;
 use namespace Slack\GraphQL;
 
 abstract class ObjectType extends NamedOutputType {
+    const type TCoerced = dict<string, mixed>;
 
     abstract public function getFieldDefinition(string $field_name): GraphQL\IFieldDefinition<this::THackType>;
 
@@ -12,7 +13,7 @@ abstract class ObjectType extends NamedOutputType {
         this::THackType $value,
         \Graphpinator\Parser\Field\IHasFieldSet $field,
         GraphQL\__Private\Variables $vars,
-    ): Awaitable<GraphQL\FieldResult> {
+    ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
         $ret = dict[];
         $errors = vec[];
         $is_valid = true;
@@ -29,7 +30,7 @@ abstract class ObjectType extends NamedOutputType {
         );
 
         foreach ($results as $key => $result) {
-            if ($result is GraphQL\ValidFieldResult) {
+            if ($result is GraphQL\ValidFieldResult<_>) {
                 $ret[$key] = $result->getValue();
             } else {
                 $is_valid = false;

--- a/src/Types/Output/OutputType.hack
+++ b/src/Types/Output/OutputType.hack
@@ -5,24 +5,25 @@ use namespace Slack\GraphQL;
  * GraphQL type that may be used for fields.
  * Includes scalar types, enums, object types, interfaces, and union types.
  *
- * TExpected is the type of the value we're expecting to receive from Hack. This is not necessarily the same as the type
- * of the value that will be returned in the GraphQL response, e.g. for object types, we expect to receive an instance
- * of a specific class from Hack, but we return a dict<string, mixed> to the GraphQL client.
+ * TExpected is the type of the value we're expecting to receive from Hack. This may or may not be the same as
+ * TResolved -- the type of the value that will be returned in the GraphQL response. For example, for object types, we
+ * expect to receive an instance of a specific class from Hack, but we return a dict<string, mixed> to the GraphQL
+ * client.
  *
  * @see https://spec.graphql.org/draft/#sec-Input-and-Output-Types
  */
-abstract class OutputType<TExpected> extends BaseType {
+abstract class OutputType<TExpected, TResolved> extends BaseType {
 
     /**
      * Use these to get a singleton list type instance wrapping this type.
      */
     <<__Memoize>>
-    public function nonNullableListOf(): ListOutputType<TExpected> {
+    public function nonNullableListOf(): ListOutputType<TExpected, TResolved> {
         return new ListOutputType($this);
     }
 
     <<__Memoize>>
-    public function nullableListOf(): NullableOutputType<vec<TExpected>> {
+    public function nullableListOf(): NullableOutputType<vec<TExpected>, vec<mixed>> {
         return new NullableOutputType($this->nonNullableListOf());
     }
 
@@ -34,12 +35,12 @@ abstract class OutputType<TExpected> extends BaseType {
         TExpected $value,
         \Graphpinator\Parser\Field\IHasFieldSet $field,
         GraphQL\__Private\Variables $vars,
-    ): Awaitable<GraphQL\FieldResult>;
+    ): Awaitable<GraphQL\FieldResult<TResolved>>;
 
     /**
      * Convert an exception thrown by the field resolver into what should be put in the GraphQL response.
      */
-    public function resolveError(GraphQL\UserFacingError $error): GraphQL\FieldResult {
+    public function resolveError(GraphQL\UserFacingError $error): GraphQL\FieldResult<TResolved> {
         return new GraphQL\InvalidFieldResult(vec[$error]);
     }
 }

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<0fbb7f9ad91541e4e77ea10eb7096fcf>>
+ * @generated SignedSource<<38704fcd24043200a19f33b802e16ecf>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -20,14 +20,14 @@ abstract final class Schema extends \Slack\GraphQL\BaseSchema {
   public static async function resolveQuery(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\__Private\Variables $variables,
-  ): Awaitable<GraphQL\ValidFieldResult> {
+  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
     return await Query::nullable()->resolveAsync(new GraphQL\Root(), $operation, $variables);
   }
 
   public static async function resolveMutation(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\__Private\Variables $variables,
-  ): Awaitable<GraphQL\ValidFieldResult> {
+  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
     return await Mutation::nullable()->resolveAsync(new GraphQL\Root(), $operation, $variables);
   }
 }


### PR DESCRIPTION
This makes it possible to more strongly type the 'data' field in `Resolver::TResponse` (statically type-checked, no runtime assertions).

Closes #46 