### PR TITLE
input object coercion

### DIFF
--- a/src/Codegen/InputObjectType.hack
+++ b/src/Codegen/InputObjectType.hack
@@ -1,0 +1,98 @@
+namespace Slack\GraphQL\Codegen;
+
+use namespace HH\Lib\{Keyset, Str};
+use type Facebook\HackCodegen\{CodegenClass, CodegenMethod, HackBuilderValues, HackCodegenFactory};
+
+class InputObjectType implements GeneratableClass {
+    public function __construct(
+        private \ReflectionTypeAlias $reflection_type_alias,
+        private \Slack\GraphQL\InputObjectType $input_type,
+    ) {}
+
+    public function getType(): string {
+        return $this->input_type->getType();
+    }
+
+    public function generateClass(HackCodegenFactory $cg): CodegenClass {
+        $hack_type = $this->reflection_type_alias->getName();
+
+        $class = $cg->codegenClass($this->input_type->getType())
+            ->setIsFinal()
+            ->setExtendsf('\%s', \Slack\GraphQL\Types\InputObjectType::class)
+            ->addTypeConstant(
+                $cg->codegenTypeConstant('TCoerced')->setValue('\\'.$hack_type, HackBuilderValues::literal()),
+            );
+
+        $name_const = $cg
+            ->codegenClassConstant('NAME')
+            ->setValue($this->input_type->getType(), HackBuilderValues::export());
+
+        $class->addConstant($name_const);
+
+        $ts = $this->reflection_type_alias->getResolvedTypeStructure();
+        invariant(
+            $ts['kind'] === \HH\TypeStructureKind::OF_SHAPE && !idx($ts, 'nullable', false),
+            'Input objects can only be generated from type aliases of a non-nullable shape type, got %s.',
+            TypeStructureKind::getNames()[$ts['kind']],
+        );
+
+        $class->addConstant(
+            $cg->codegenClassConstant('keyset<string> FIELD_NAMES')
+                ->setValue(Keyset\keys($ts['fields']), HackBuilderValues::export()),
+        );
+
+        // coerceFieldValues() and coerceFieldNodes()
+        $values = hb($cg)->addLine('return shape(')->indent();
+        $nodes = hb($cg)->addLine('return shape(')->indent();
+
+        foreach (($ts['fields'] as nonnull) as $field_name => $field_ts) {
+            $name_literal = \var_export($field_name, true);
+            $type = input_type(self::typeStructureToHackType($field_ts));
+            $values->addLinef('%s => %s->coerceValue($args[%s]),', $name_literal, $type, $name_literal);
+            $nodes->addLinef('%s => %s->coerceNode($args[%s], $vars),', $name_literal, $type, $name_literal);
+        }
+
+        $values->unindent()->addLine(');');
+        $nodes->unindent()->addLine(');');
+
+        return $class->addMethods(vec[
+            $cg->codegenMethod('coerceFieldValues')
+                ->setIsOverride()
+                ->addParameter('KeyedContainer<arraykey, mixed> $args')
+                ->setReturnType('this::TCoerced')
+                ->setBody($values->getCode()),
+            $cg->codegenMethod('coerceFieldNodes')
+                ->setIsOverride()
+                ->addParameterf('KeyedContainer<string, \\%s> $args', \Graphpinator\Parser\Value\Value::class)
+                ->addParameter('dict<string, mixed> $vars')
+                ->setReturnType('this::TCoerced')
+                ->setBody($nodes->getCode()),
+        ]);
+    }
+
+    private static function typeStructureToHackType<T>(TypeStructure<T> $ts): string {
+        $alias = Shapes::idx($ts, 'alias');
+        if ($alias is nonnull) {
+            return $alias;
+        }
+
+        switch ($ts['kind']) {
+            case TypeStructureKind::OF_INT:
+                return 'HH\int';
+            case TypeStructureKind::OF_STRING:
+                return 'HH\string';
+            case TypeStructureKind::OF_BOOL:
+                return 'HH\bool';
+            case TypeStructureKind::OF_VEC:
+                return Str\format('HH\vec<%s>', self::typeStructureToHackType($ts['generic_types'] as nonnull[0]));
+            case TypeStructureKind::OF_ENUM:
+            //case TypeStructureKind::OF_UNRESOLVED: // not sure if this is needed
+                return $ts['classname'] as nonnull;
+            default:
+                invariant_violation(
+                    'Shape fields %s cannot be used as input object fields.',
+                    TypeStructureKind::getNames()[$ts['kind']],
+                );
+        }
+    }
+}

--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -25,7 +25,8 @@ function input_type(string $hack_type): string {
             $class = get_input_class($unwrapped);
             if ($class is null) {
                 throw new \Error(
-                    'GraphQL\Field argument types must be scalar or be enums annnotated with a GraphQL attribute',
+                    'GraphQL\Field argument types must be scalar or be enums/input objects annnotated with a GraphQL '.
+                    'attribute, got '.$unwrapped,
                 );
             }
     }

--- a/src/Types/Input/EnumInputType.hack
+++ b/src/Types/Input/EnumInputType.hack
@@ -25,6 +25,8 @@ abstract class EnumInputType extends NamedInputType {
     }
 
     final protected function assertValidVariableValue(mixed $value): this::TCoerced {
+        // TODO: This should just be $value as this::TCoerced, once variables are properly coerced at the beginning
+        // of execution. Otherwise we'd try (and fail) to coerce an already-coerced value here.
         $enum = static::HACK_ENUM;
         return $enum::getValues()[$value as string];
     }

--- a/src/Types/Input/InputObjectType.hack
+++ b/src/Types/Input/InputObjectType.hack
@@ -1,37 +1,59 @@
 namespace Slack\GraphQL\Types;
 
-use namespace Facebook\{TypeCoerce, TypeAssert};
+use namespace HH\Lib\C;
+use namespace Slack\GraphQL;
+use namespace Graphpinator\Parser\Value;
 
 <<__ConsistentConstruct>>
-abstract class InputObjectType<TCoerced as nonnull> extends InputType<TCoerced> {
+abstract class InputObjectType extends NamedInputType {
 
-    abstract const string NAME;
-    abstract public function coerceValue(mixed $value): TCoerced;
-    abstract public function assertValidVariableValue(mixed $value): TCoerced;
+    <<__Enforceable>>
+    abstract const type TCoerced as shape(...);
+    abstract const keyset<string> FIELD_NAMES;
 
-    <<__Override>>
-    final public function getName(): string {
-        return static::NAME;
+    final protected function assertValidVariableValue(mixed $value): this::TCoerced {
+        return $value as this::TCoerced;
     }
 
     <<__Override>>
-    final public function coerceNonVariableNode(
-        \Graphpinator\Parser\Value\Value $node,
+    public function coerceValue(mixed $value): this::TCoerced {
+        if (!$value is KeyedContainer<_, _>) {
+            throw new GraphQL\UserFacingError('Expected an input object (a dict/map), got %s', \gettype($value));
+        }
+        foreach ($value as $key => $_) {
+            GraphQL\assert(
+                C\contains_key(static::FIELD_NAMES, $key),
+                'Undefined field "%s" on "%s"',
+                (string)$key,
+                static::NAME,
+            );
+        }
+        return $this->coerceFieldValues($value);
+    }
+
+    abstract protected function coerceFieldValues(KeyedContainer<arraykey, mixed> $values): this::TCoerced;
+
+    <<__Override>>
+    protected function coerceNonVariableNode(
+        Value\Value $node,
         dict<string, mixed> $variable_values,
-    ): TCoerced {
-        return $this->coerceValue($node->getRawValue());
+    ): this::TCoerced {
+        if (!$node is Value\ObjectVal) {
+            throw new GraphQL\UserFacingError('Expected an input object literal, got %s', \get_class($node));
+        }
+        foreach ($node->getValue() as $key => $_) {
+            GraphQL\assert(
+                C\contains_key(static::FIELD_NAMES, $key),
+                'Undefined field "%s" on "%s"',
+                (string)$key,
+                static::NAME,
+            );
+        }
+        return $this->coerceFieldNodes($node->getValue(), $variable_values);
     }
 
-    /**
-     * Use these to get the singleton instance of this type.
-     */
-    <<__MemoizeLSB>>
-    final public static function nonNullable(): this {
-        return new static();
-    }
-
-    <<__MemoizeLSB>>
-    final public static function nullable(): \Slack\GraphQL\Types\NullableInputType<TCoerced> {
-        return new \Slack\GraphQL\Types\NullableInputType(static::nonNullable());
-    }
+    abstract protected function coerceFieldNodes(
+        KeyedContainer<string, Value\Value> $value_nodes,
+        dict<string, mixed> $variable_values,
+    ): this::TCoerced;
 }

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -50,6 +50,7 @@ type TCreateUserInput = shape(
     'name' => string,
     ?'is_active' => bool,
     ?'team' => TCreateTeamInput,
+    ?'favorite_color' => FavoriteColor,
 );
 
 final class TeamStore {

--- a/tests/InputTypeTest.hack
+++ b/tests/InputTypeTest.hack
@@ -94,6 +94,95 @@ final class InputTypeTest extends PlaygroundTest {
                     ],
                 ],
             ),
+
+            'input object literal' => tuple(
+                'mutation CreateUser {
+                    createUser(input: {
+                        name: "New User"
+                        is_active: false
+                        team: {name: "New Team"}
+                        favorite_color: RED
+                    }) {
+                        id
+                        is_active
+                        name
+                        team { name }
+                    }
+                }',
+                dict[],
+                dict[
+                    'createUser' => dict[
+                        'id' => 3,
+                        'is_active' => false,
+                        'name' => 'New User',
+                        'team' => dict['name' => 'New Team'],
+                    ],
+                ],
+            ),
+
+            'input object literal with variable references' => tuple(
+                'mutation CreateUser(
+                    $name: String!
+                    $is_active: Boolean!
+                    $team_name: String!
+                    $favorite_color: FavoriteColor!
+                ) {
+                    createUser(input: {
+                        name: $name
+                        is_active: $is_active
+                        team: {name: $team_name}
+                        favorite_color: $favorite_color
+                    }) {
+                        id
+                        is_active
+                        name
+                        team { name }
+                    }
+                }',
+                dict[
+                    'name' => 'New User',
+                    'is_active' => false,
+                    'team_name' => 'New Team',
+                    'favorite_color' => 'RED',
+                ],
+                dict[
+                    'createUser' => dict[
+                        'id' => 3,
+                        'is_active' => false,
+                        'name' => 'New User',
+                        'team' => dict['name' => 'New Team'],
+                    ],
+                ],
+            ),
+
+            'nested input object variable' => tuple(
+                'mutation CreateUser(
+                    $team: CreateTeamInput!
+                ) {
+                    createUser(input: {
+                        name: "New User"
+                        is_active: false
+                        team: $team
+                        favorite_color: RED
+                    }) {
+                        id
+                        is_active
+                        name
+                        team { name }
+                    }
+                }',
+                dict[
+                    'team' => dict['name' => 'New Team'],
+                ],
+                dict[
+                    'createUser' => dict[
+                        'id' => 3,
+                        'is_active' => false,
+                        'name' => 'New User',
+                        'team' => dict['name' => 'New Team'],
+                    ],
+                ],
+            ),
         ];
     }
 

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<6bfadaf760e52cee58f41774dbbc6b15>>
+ * @generated SignedSource<<799aeafc0808025f3359dfcc90687109>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -423,38 +423,67 @@ final class FavoriteColorOutputType
   const \HH\enumname<this::THackType> HACK_ENUM = \FavoriteColor::class;
 }
 
-final class CreateTeamInput
-  extends \Slack\GraphQL\Types\InputObjectType<\TCreateTeamInput> {
+final class CreateTeamInput extends \Slack\GraphQL\Types\InputObjectType {
 
+  const type TCoerced = \TCreateTeamInput;
   const NAME = 'CreateTeamInput';
+  const keyset<string> FIELD_NAMES = keyset [
+    'name',
+  ];
 
   <<__Override>>
-  final public function coerceValue(mixed $value): \TCreateTeamInput {
-    return TypeCoerce\match_type_structure(\HH\type_structure_for_alias(\TCreateTeamInput::class), $value);;
+  public function coerceFieldValues(
+    KeyedContainer<arraykey, mixed> $args,
+  ): this::TCoerced {
+    return shape(
+      'name' => Types\StringInputType::nonNullable()->coerceValue($args['name']),
+    );
   }
 
   <<__Override>>
-  final public function assertValidVariableValue(
-    mixed $value,
-  ): \TCreateTeamInput {
-    return TypeAssert\matches_type_structure(\HH\type_structure_for_alias(\TCreateTeamInput::class), $value);;
+  public function coerceFieldNodes(
+    KeyedContainer<string, \Graphpinator\Parser\Value\Value> $args,
+    dict<string, mixed> $vars,
+  ): this::TCoerced {
+    return shape(
+      'name' => Types\StringInputType::nonNullable()->coerceNode($args['name'], $vars),
+    );
   }
 }
 
-final class CreateUserInput
-  extends \Slack\GraphQL\Types\InputObjectType<\TCreateUserInput> {
+final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
 
+  const type TCoerced = \TCreateUserInput;
   const NAME = 'CreateUserInput';
+  const keyset<string> FIELD_NAMES = keyset [
+    'name',
+    'is_active',
+    'team',
+    'favorite_color',
+  ];
 
   <<__Override>>
-  final public function coerceValue(mixed $value): \TCreateUserInput {
-    return TypeCoerce\match_type_structure(\HH\type_structure_for_alias(\TCreateUserInput::class), $value);;
+  public function coerceFieldValues(
+    KeyedContainer<arraykey, mixed> $args,
+  ): this::TCoerced {
+    return shape(
+      'name' => Types\StringInputType::nonNullable()->coerceValue($args['name']),
+      'is_active' => Types\BooleanInputType::nonNullable()->coerceValue($args['is_active']),
+      'team' => CreateTeamInput::nonNullable()->coerceValue($args['team']),
+      'favorite_color' => FavoriteColorInputType::nonNullable()->coerceValue($args['favorite_color']),
+    );
   }
 
   <<__Override>>
-  final public function assertValidVariableValue(
-    mixed $value,
-  ): \TCreateUserInput {
-    return TypeAssert\matches_type_structure(\HH\type_structure_for_alias(\TCreateUserInput::class), $value);;
+  public function coerceFieldNodes(
+    KeyedContainer<string, \Graphpinator\Parser\Value\Value> $args,
+    dict<string, mixed> $vars,
+  ): this::TCoerced {
+    return shape(
+      'name' => Types\StringInputType::nonNullable()->coerceNode($args['name'], $vars),
+      'is_active' => Types\BooleanInputType::nonNullable()->coerceNode($args['is_active'], $vars),
+      'team' => CreateTeamInput::nonNullable()->coerceNode($args['team'], $vars),
+      'favorite_color' => FavoriteColorInputType::nonNullable()->coerceNode($args['favorite_color'], $vars),
+    );
   }
 }


### PR DESCRIPTION
- supports variables nested inside an input object literal (see new test cases)
- supports enum fields (which need to be coerced between const name <-> internal value, which previously wouldn't happen)
- the generated code is type-safe without runtime assertions (TypeAssert), so if we ever introduce a bug into the codegen, Hack should catch it

This doesn't yet handle optional/nullable fields, I'll do those separately tomorrow.

I moved InputObjectType out of Generator.hack since that file was getting very long.

The easiest way to review this is probably look at the changes to the codegen output (Generated.hack) first, the rest should become pretty obvious after that.