### PR TITLE
support optional input object fields

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -281,7 +281,7 @@ final class Generator {
             ->setFileType(CodegenFileType::DOT_HACK)
             ->useNamespace('Slack\\GraphQL')
             ->useNamespace('Slack\\GraphQL\\Types')
-            ->useNamespace('HH\\Lib\\Dict')
+            ->useNamespace('HH\\Lib\\{C, Dict}')
             ->addClass($this->generateSchemaType($this->cg));
 
         $has_type_assertions = false;

--- a/src/Codegen/InputObjectType.hack
+++ b/src/Codegen/InputObjectType.hack
@@ -42,28 +42,49 @@ class InputObjectType implements GeneratableClass {
         );
 
         // coerceFieldValues() and coerceFieldNodes()
-        $values = hb($cg)->addLine('return shape(')->indent();
-        $nodes = hb($cg)->addLine('return shape(')->indent();
+        $values = hb($cg)->addLine('$ret = shape();');
+        $nodes = hb($cg)->addLine('$ret = shape();');
 
         foreach (($ts['fields'] as nonnull) as $field_name => $field_ts) {
+            $is_optional = $field_ts['optional_shape_field'] ?? false;
+            $is_nullable = $field_ts['nullable'] ?? false;
+            invariant(
+                $is_optional === $is_nullable,
+                'Field "%s" must be both optional and nullable, or neither (GraphQL doesn\'t distinguish between '.
+                'optionality and nullability)',
+                $field_name,
+            );
+
             $name_literal = \var_export($field_name, true);
-            $type = input_type(self::typeStructureToHackType($field_ts));
-            $values->addLinef('%s => %s->coerceValue($args[%s]),', $name_literal, $type, $name_literal);
-            $nodes->addLinef('%s => %s->coerceNode($args[%s], $vars),', $name_literal, $type, $name_literal);
+            $type = input_type(($is_optional ? '?' : '').self::typeStructureToHackType($field_ts));
+
+            if ($is_optional) {
+                $values->startIfBlockf('C\\contains_key($fields, %s)', $name_literal);
+                $nodes->startIfBlockf('$this->hasValue(%s, $fields, $vars)', $name_literal);
+            }
+
+            $values->addLinef('$ret[%s] = %s->coerceNamedValue(%s, $fields);', $name_literal, $type, $name_literal);
+            $nodes
+                ->addLinef('$ret[%s] = %s->coerceNamedNode(%s, $fields, $vars);', $name_literal, $type, $name_literal);
+
+            if ($is_optional) {
+                $values->endIfBlock();
+                $nodes->endIfBlock();
+            }
         }
 
-        $values->unindent()->addLine(');');
-        $nodes->unindent()->addLine(');');
+        $values->addReturn('$ret', HackBuilderValues::literal());
+        $nodes->addReturn('$ret', HackBuilderValues::literal());
 
         return $class->addMethods(vec[
             $cg->codegenMethod('coerceFieldValues')
                 ->setIsOverride()
-                ->addParameter('KeyedContainer<arraykey, mixed> $args')
+                ->addParameter('KeyedContainer<arraykey, mixed> $fields')
                 ->setReturnType('this::TCoerced')
                 ->setBody($values->getCode()),
             $cg->codegenMethod('coerceFieldNodes')
                 ->setIsOverride()
-                ->addParameterf('KeyedContainer<string, \\%s> $args', \Graphpinator\Parser\Value\Value::class)
+                ->addParameterf('dict<string, \\%s> $fields', \Graphpinator\Parser\Value\Value::class)
                 ->addParameter('dict<string, mixed> $vars')
                 ->setReturnType('this::TCoerced')
                 ->setBody($nodes->getCode()),

--- a/src/Types/Input/InputObjectType.hack
+++ b/src/Types/Input/InputObjectType.hack
@@ -53,7 +53,30 @@ abstract class InputObjectType extends NamedInputType {
     }
 
     abstract protected function coerceFieldNodes(
-        KeyedContainer<string, Value\Value> $value_nodes,
+        dict<string, Value\Value> $value_nodes,
         dict<string, mixed> $variable_values,
     ): this::TCoerced;
+
+    /**
+     * Follows the GraphQL spec rules for whether a field should be included in the coerced shape -- either a literal
+     * value was provided, or the value is a variable reference and *that variable was provided*. This means that by
+     * including/not including a specific variable in the request, a field can be added/removed from any input object
+     * literals that reference the variable, which is powerful but can also be confusing.
+     *
+     * @see https://spec.graphql.org/draft/#sec-Input-Objects.Input-Coercion
+     */
+    final protected function hasValue(
+        string $field_name,
+        dict<string, Value\Value> $value_nodes,
+        dict<string, mixed> $variable_values,
+    ): bool {
+        if (!C\contains_key($value_nodes, $field_name)) {
+            return false;
+        }
+        $value_node = $value_nodes[$field_name];
+        if ($value_node is Value\VariableRef) {
+            return C\contains_key($variable_values, $value_node->getVarName());
+        }
+        return true;
+    }
 }

--- a/src/UserFacingError.hack
+++ b/src/UserFacingError.hack
@@ -25,6 +25,14 @@ class UserFacingError extends \Exception {
         parent::__construct(\vsprintf($message, $args));
     }
 
+    final public function prependMessage(
+        Str\SprintfFormatString $message,
+        mixed ...$args
+    ): this {
+        $this->message = \vsprintf($message, $args).': '.$this->message;
+        return $this;
+    }
+
     final public function prependPath(arraykey $key): this {
         $this->reversePath[] = $key;
         return $this;

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -48,9 +48,9 @@ type TCreateTeamInput = shape(
 <<GraphQL\InputObjectType('CreateUserInput', 'Arguments for creating a user')>>
 type TCreateUserInput = shape(
     'name' => string,
-    ?'is_active' => bool,
-    ?'team' => TCreateTeamInput,
-    ?'favorite_color' => FavoriteColor,
+    ?'is_active' => ?bool,
+    ?'team' => ?TCreateTeamInput,
+    ?'favorite_color' => ?FavoriteColor,
 );
 
 final class TeamStore {
@@ -200,6 +200,14 @@ abstract final class UserQueryAttributes {
     <<GraphQL\QueryRootField('takes_favorite_color', 'Test for enum arguments')>>
     public static function takesFavoriteColor(FavoriteColor $favorite_color): bool {
         return true;
+    }
+
+    <<GraphQL\QueryRootField('optional_field_test', 'Test for an optional input object field')>>
+    public static function optionalFieldTest(TCreateUserInput $input): string {
+        if (!Shapes::keyExists($input, 'favorite_color')) {
+            return 'color is missing';
+        }
+        return $input['favorite_color'] is null ? 'color is null' : 'color is non-null';
     }
 }
 

--- a/tests/InputTypeTest.hack
+++ b/tests/InputTypeTest.hack
@@ -183,6 +183,54 @@ final class InputTypeTest extends PlaygroundTest {
                     ],
                 ],
             ),
+
+            'optional input object field (literal)' => tuple(
+                '{
+                    expect_missing: optional_field_test(input: {name: "foo"})
+                    expect_null:    optional_field_test(input: {name: "foo", favorite_color: null})
+                    expect_nonnull: optional_field_test(input: {name: "foo", favorite_color: RED})
+                }',
+                dict[],
+                dict[
+                    'expect_missing' => 'color is missing',
+                    'expect_null' => 'color is null',
+                    'expect_nonnull' => 'color is non-null',
+                ],
+            ),
+
+            'optional input object field (missing variable)' => tuple(
+                'query ($color: FavoriteColor) {
+                    optional_field_test(input: {name: "foo", favorite_color: $color})
+                }',
+                dict[], // no variables
+                dict['optional_field_test' => 'color is missing'],
+            ),
+
+            'optional input object field (null variable)' => tuple(
+                'query ($color: FavoriteColor) {
+                    optional_field_test(input: {name: "foo", favorite_color: $color})
+                }',
+                dict['color' => null],
+                dict['optional_field_test' => 'color is null'],
+            ),
+
+            /* TODO: doesn't work yet (needs variable coercion)
+            'optional input object field (missing variable with default)' => tuple(
+                'query ($color: FavoriteColor = RED) {
+                    optional_field_test(input: {name: "foo", favorite_color: $color})
+                }',
+                dict[], // no variables
+                dict['optional_field_test' => 'color is non-null'],
+            ),
+            */
+
+            'optional input object field (null variable with default)' => tuple(
+                'query ($color: FavoriteColor = RED) {
+                    optional_field_test(input: {name: "foo", favorite_color: $color})
+                }',
+                dict['color' => null],
+                dict['optional_field_test' => 'color is null'],
+            ),
         ];
     }
 

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,12 +4,12 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<2fd9942046ca85bed913f4a4733c55dc>>
+ * @generated SignedSource<<b703dd24fc9dc008cbe3088dace5d168>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
-use namespace HH\Lib\Dict;
+use namespace HH\Lib\{C, Dict};
 use namespace Facebook\TypeAssert;
 use namespace Facebook\TypeCoerce;
 
@@ -50,21 +50,6 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           ErrorTest::nonNullable(),
           async ($parent, $args, $vars) ==> \ErrorTestObj::getNonNullable(),
-        );
-      case 'getConcrete':
-        return new GraphQL\FieldDefinition(
-          Concrete::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
-        );
-      case 'getInterfaceA':
-        return new GraphQL\FieldDefinition(
-          InterfaceA::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
-        );
-      case 'getInterfaceB':
-        return new GraphQL\FieldDefinition(
-          InterfaceB::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
         );
       case 'output_type_test':
         return new GraphQL\FieldDefinition(
@@ -111,6 +96,28 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
             FavoriteColorInputType::nonNullable()->coerceNode($args['favorite_color']->getValue(), $vars),
           ),
         );
+      case 'optional_field_test':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::optionalFieldTest(
+            CreateUserInput::nonNullable()->coerceNode($args['input']->getValue(), $vars),
+          ),
+        );
+      case 'getConcrete':
+        return new GraphQL\FieldDefinition(
+          Concrete::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
+        );
+      case 'getInterfaceA':
+        return new GraphQL\FieldDefinition(
+          InterfaceA::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
+        );
+      case 'getInterfaceB':
+        return new GraphQL\FieldDefinition(
+          InterfaceB::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
+        );
       default:
         throw new \Exception('Unknown field: '.$field_name);
     }
@@ -139,6 +146,41 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
           async ($parent, $args, $vars) ==> await \UserMutationAttributes::createUser(
             CreateUserInput::nonNullable()->coerceNode($args['input']->getValue(), $vars),
           ),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
+final class User extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \User;
+  const NAME = 'User';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'id':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->getId(),
+        );
+      case 'name':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->getName(),
+        );
+      case 'team':
+        return new GraphQL\FieldDefinition(
+          Team::nullable(),
+          async ($parent, $args, $vars) ==> await $parent->getTeam(),
+        );
+      case 'is_active':
+        return new GraphQL\FieldDefinition(
+          Types\BooleanOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -184,41 +226,6 @@ final class InterfaceB extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           Types\StringOutputType::nullable(),
           async ($parent, $args, $vars) ==> $parent->bar(),
-        );
-      default:
-        throw new \Exception('Unknown field: '.$field_name);
-    }
-  }
-}
-
-final class User extends \Slack\GraphQL\Types\ObjectType {
-
-  const type THackType = \User;
-  const NAME = 'User';
-
-  public function getFieldDefinition(
-    string $field_name,
-  ): GraphQL\IFieldDefinition<this::THackType> {
-    switch ($field_name) {
-      case 'id':
-        return new GraphQL\FieldDefinition(
-          Types\IntOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->getId(),
-        );
-      case 'name':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->getName(),
-        );
-      case 'team':
-        return new GraphQL\FieldDefinition(
-          Team::nullable(),
-          async ($parent, $args, $vars) ==> await $parent->getTeam(),
-        );
-      case 'is_active':
-        return new GraphQL\FieldDefinition(
-          Types\BooleanOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -294,36 +301,6 @@ final class ErrorTest extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           ErrorTest::nonNullable()->nonNullableListOf(),
           async ($parent, $args, $vars) ==> $parent->nested_list_nn_of_nn(),
-        );
-      default:
-        throw new \Exception('Unknown field: '.$field_name);
-    }
-  }
-}
-
-final class Concrete extends \Slack\GraphQL\Types\ObjectType {
-
-  const type THackType = \Concrete;
-  const NAME = 'Concrete';
-
-  public function getFieldDefinition(
-    string $field_name,
-  ): GraphQL\IFieldDefinition<this::THackType> {
-    switch ($field_name) {
-      case 'foo':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->foo(),
-        );
-      case 'bar':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->bar(),
-        );
-      case 'baz':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->baz(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -498,6 +475,36 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
   }
 }
 
+final class Concrete extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \Concrete;
+  const NAME = 'Concrete';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'foo':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->foo(),
+        );
+      case 'bar':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->bar(),
+        );
+      case 'baz':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->baz(),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
 final class FavoriteColorInputType extends \Slack\GraphQL\Types\EnumInputType {
 
   const NAME = 'FavoriteColor';
@@ -523,21 +530,21 @@ final class CreateTeamInput extends \Slack\GraphQL\Types\InputObjectType {
 
   <<__Override>>
   public function coerceFieldValues(
-    KeyedContainer<arraykey, mixed> $args,
+    KeyedContainer<arraykey, mixed> $fields,
   ): this::TCoerced {
-    return shape(
-      'name' => Types\StringInputType::nonNullable()->coerceValue($args['name']),
-    );
+    $ret = shape();
+    $ret['name'] = Types\StringInputType::nonNullable()->coerceNamedValue('name', $fields);
+    return $ret;
   }
 
   <<__Override>>
   public function coerceFieldNodes(
-    KeyedContainer<string, \Graphpinator\Parser\Value\Value> $args,
+    dict<string, \Graphpinator\Parser\Value\Value> $fields,
     dict<string, mixed> $vars,
   ): this::TCoerced {
-    return shape(
-      'name' => Types\StringInputType::nonNullable()->coerceNode($args['name'], $vars),
-    );
+    $ret = shape();
+    $ret['name'] = Types\StringInputType::nonNullable()->coerceNamedNode('name', $fields, $vars);
+    return $ret;
   }
 }
 
@@ -554,26 +561,38 @@ final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
 
   <<__Override>>
   public function coerceFieldValues(
-    KeyedContainer<arraykey, mixed> $args,
+    KeyedContainer<arraykey, mixed> $fields,
   ): this::TCoerced {
-    return shape(
-      'name' => Types\StringInputType::nonNullable()->coerceValue($args['name']),
-      'is_active' => Types\BooleanInputType::nonNullable()->coerceValue($args['is_active']),
-      'team' => CreateTeamInput::nonNullable()->coerceValue($args['team']),
-      'favorite_color' => FavoriteColorInputType::nonNullable()->coerceValue($args['favorite_color']),
-    );
+    $ret = shape();
+    $ret['name'] = Types\StringInputType::nonNullable()->coerceNamedValue('name', $fields);
+    if (C\contains_key($fields, 'is_active')) {
+      $ret['is_active'] = Types\BooleanInputType::nullable()->coerceNamedValue('is_active', $fields);
+    }
+    if (C\contains_key($fields, 'team')) {
+      $ret['team'] = CreateTeamInput::nullable()->coerceNamedValue('team', $fields);
+    }
+    if (C\contains_key($fields, 'favorite_color')) {
+      $ret['favorite_color'] = FavoriteColorInputType::nullable()->coerceNamedValue('favorite_color', $fields);
+    }
+    return $ret;
   }
 
   <<__Override>>
   public function coerceFieldNodes(
-    KeyedContainer<string, \Graphpinator\Parser\Value\Value> $args,
+    dict<string, \Graphpinator\Parser\Value\Value> $fields,
     dict<string, mixed> $vars,
   ): this::TCoerced {
-    return shape(
-      'name' => Types\StringInputType::nonNullable()->coerceNode($args['name'], $vars),
-      'is_active' => Types\BooleanInputType::nonNullable()->coerceNode($args['is_active'], $vars),
-      'team' => CreateTeamInput::nonNullable()->coerceNode($args['team'], $vars),
-      'favorite_color' => FavoriteColorInputType::nonNullable()->coerceNode($args['favorite_color'], $vars),
-    );
+    $ret = shape();
+    $ret['name'] = Types\StringInputType::nonNullable()->coerceNamedNode('name', $fields, $vars);
+    if ($this->hasValue('is_active', $fields, $vars)) {
+      $ret['is_active'] = Types\BooleanInputType::nullable()->coerceNamedNode('is_active', $fields, $vars);
+    }
+    if ($this->hasValue('team', $fields, $vars)) {
+      $ret['team'] = CreateTeamInput::nullable()->coerceNamedNode('team', $fields, $vars);
+    }
+    if ($this->hasValue('favorite_color', $fields, $vars)) {
+      $ret['favorite_color'] = FavoriteColorInputType::nullable()->coerceNamedNode('favorite_color', $fields, $vars);
+    }
+    return $ret;
   }
 }


### PR DESCRIPTION
The docblock for `hasValue()` and the new test cases are probably the most interesting parts to look at here.

To implement the correct behavior per the GraphQL spec, I had to add the restriction that each field must be both optional and nullable, or neither. If you think this will be too inconvenient, it's probably possible to avoid it, but it will result in some cases that are not covered by the spec where we'll have to decide what to do with them (e.g. if the spec say we should omit a field, where that field is nullable but not optional in Hack, I guess we'd have to put null in there instead of omitting it?).