### PR TITLE
Support annotating shapes with GraphQL\ObjectType

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -437,9 +437,14 @@ final class Generator {
         foreach ($input_types as $type) {
             $rt = new \ReflectionTypeAlias($type->getName());
             $graphql_input = $rt->getAttributeClass(\Slack\GraphQL\InputObjectType::class);
-            if ($graphql_input is null) continue;
+            if ($graphql_input is nonnull) {
+                $inputs[] = new InputObjectType($rt, $graphql_input);
+            }
 
-            $inputs[] = new InputObjectType($rt, $graphql_input);
+            $graphql_output = $rt->getAttributeClass(\Slack\GraphQL\ObjectType::class);
+            if ($graphql_output is nonnull) {
+                $objects[] = new OutputObjectType($rt, $graphql_output);
+            }
         }
 
         $classish_objects = $this->parser->getInterfaces() |> Vec\concat($$, $this->parser->getClasses());

--- a/src/Codegen/InputObjectType.hack
+++ b/src/Codegen/InputObjectType.hack
@@ -64,7 +64,7 @@ class InputObjectType implements GeneratableClass {
             );
 
             $name_literal = \var_export($field_name, true);
-            $type = input_type(($is_optional ? '?' : '').self::typeStructureToHackType($field_ts));
+            $type = input_type(($is_optional ? '?' : '').type_structure_to_type_alias($field_ts));
 
             if ($is_optional) {
                 $values->startIfBlockf('C\\contains_key($fields, %s)', $name_literal);
@@ -97,31 +97,5 @@ class InputObjectType implements GeneratableClass {
                 ->setReturnType('this::TCoerced')
                 ->setBody($nodes->getCode()),
         ]);
-    }
-
-    private static function typeStructureToHackType<T>(TypeStructure<T> $ts): string {
-        $alias = Shapes::idx($ts, 'alias');
-        if ($alias is nonnull) {
-            return $alias;
-        }
-
-        switch ($ts['kind']) {
-            case TypeStructureKind::OF_INT:
-                return 'HH\int';
-            case TypeStructureKind::OF_STRING:
-                return 'HH\string';
-            case TypeStructureKind::OF_BOOL:
-                return 'HH\bool';
-            case TypeStructureKind::OF_VEC:
-                return Str\format('HH\vec<%s>', self::typeStructureToHackType($ts['generic_types'] as nonnull[0]));
-            case TypeStructureKind::OF_ENUM:
-            //case TypeStructureKind::OF_UNRESOLVED: // not sure if this is needed
-                return $ts['classname'] as nonnull;
-            default:
-                invariant_violation(
-                    'Shape fields %s cannot be used as input object fields.',
-                    TypeStructureKind::getNames()[$ts['kind']],
-                );
-        }
     }
 }

--- a/src/Codegen/OutputObjectType.hack
+++ b/src/Codegen/OutputObjectType.hack
@@ -1,0 +1,91 @@
+namespace Slack\GraphQL\Codegen;
+
+use namespace HH\Lib\{Keyset, Str};
+use type Facebook\HackCodegen\{CodegenClass, CodegenMethod, HackBuilderValues, HackCodegenFactory};
+
+
+class OutputObjectType implements GeneratableClass {
+    public function __construct(
+        private \ReflectionTypeAlias $reflection_type_alias,
+        private \Slack\GraphQL\ObjectType $object_type 
+    ) {}
+
+    public function getInputTypeName(): null {
+        return null;
+    }
+
+    public function getOutputTypeName(): string {
+        return $this->object_type->getType();
+    }
+
+    public function generateClass(HackCodegenFactory $cg): CodegenClass {
+        $hack_type = $this->reflection_type_alias->getName();
+
+        $class = $cg->codegenClass($this->object_type->getType())
+            ->setExtendsf('\%s', \Slack\GraphQL\Types\ObjectType::class);
+
+        $hack_type_constant = $cg->codegenClassConstant('THackType')
+            ->setType('type')
+            ->setValue('\\'.$this->reflection_type_alias->getName(), HackBuilderValues::literal());
+
+        $class->addConstant($hack_type_constant);
+        $class->addConstant(
+            $cg->codegenClassConstant('NAME')->setValue($this->object_type->getType(), HackBuilderValues::export()),
+        );
+
+        $class->addMethod($this->generateGetFieldDefinition($cg));
+
+        return $class;
+    }
+
+
+    protected function generateGetFieldDefinition(HackCodegenFactory $cg): CodegenMethod {
+        $method = $cg->codegenMethod('getFieldDefinition')
+            ->setPublic()
+            ->setReturnType('GraphQL\\IFieldDefinition<this::THackType>')
+            ->addParameter('string $field_name');
+
+        $ts = $this->reflection_type_alias->getResolvedTypeStructure();
+        invariant(
+            $ts['kind'] === \HH\TypeStructureKind::OF_SHAPE && !idx($ts, 'nullable', false),
+            'Output objects can only be generated from type aliases of a non-nullable shape type, got %s.',
+            TypeStructureKind::getNames()[$ts['kind']],
+        );
+
+        $hb = hb($cg);
+        $hb->startSwitch('$field_name')
+            ->addCaseBlocks(
+                Keyset\keys($ts['fields']),
+                ($field_name, $hb) ==> {
+                    $name_literal = \var_export($field_name, true);
+
+                    $hb->addCase($name_literal, HackBuilderValues::literal());
+                    $hb->addLine('return new GraphQL\\FieldDefinition(')->indent();
+
+                    // Field return type
+                    $field_ts = $ts['fields'][$field_name];
+                    $type_info = output_type(type_structure_to_type_alias($field_ts), false);
+                    $hb->addLinef('%s,', $type_info['type']);
+
+                    $hb->addf(
+                        'async ($parent, $args, $vars) ==> $parent[%s]%s',
+                        $name_literal,
+                        Shapes::idx($field_ts, 'optional_shape_field', false) ? ' ?? null' : ''
+                    );
+                    $hb->addLine(',');
+
+                    // End of new GraphQL\FieldDefinition(
+                    $hb->unindent()->addLine(');');
+                    $hb->unindent();
+                },
+            )
+            ->addDefault()
+            ->addLine("throw new \Exception('Unknown field: '.\$field_name);")
+            ->endDefault()
+            ->endSwitch();
+
+        $method->setBody($hb->getCode());
+
+        return $method;
+    }
+}

--- a/src/Types/Output/NamedOutputType.hack
+++ b/src/Types/Output/NamedOutputType.hack
@@ -11,7 +11,6 @@ namespace Slack\GraphQL\Types;
 <<__ConsistentConstruct>>
 abstract class NamedOutputType extends OutputType<this::THackType, this::TCoerced> {
 
-    <<__Enforceable>>
     abstract const type THackType;
     abstract const type TCoerced;
     abstract const string NAME;

--- a/src/__Private/Attributes/CompositeType.hack
+++ b/src/__Private/Attributes/CompositeType.hack
@@ -1,6 +1,6 @@
 namespace Slack\GraphQL\__Private;
 
-class CompositeType implements \HH\ClassAttribute {
+class CompositeType implements \HH\ClassAttribute, \HH\TypeAliasAttribute {
     public function __construct(private string $type, private string $description) {}
 
     public function getType(): string {

--- a/src/playground/ObjectTypeTestObjects.hack
+++ b/src/playground/ObjectTypeTestObjects.hack
@@ -1,0 +1,28 @@
+use namespace Slack\GraphQL;
+
+
+abstract final class ObjectTypeTestEntrypoint {
+    <<GraphQL\QueryRootField('getObjectShape', 'fetch an object shape')>>
+    public static function getObjectShape(): ObjectShape {
+        return shape(
+            'foo' => 3,
+            'baz' => shape(
+                'abc' => vec[1, 2, 3]
+            )
+        );
+    }
+}
+
+
+<<GraphQL\ObjectType('ObjectShape', 'ObjectShape')>>
+type ObjectShape = shape(
+    'foo' => int,
+    ?'bar' => string,
+    'baz' => AnotherObjectShape
+);
+
+
+<<GraphQL\ObjectType('AnotherObjectShape', 'AnotherObjectShape')>>
+type AnotherObjectShape = shape(
+    'abc' => vec<int>
+);

--- a/tests/ObjectTypeTest.hack
+++ b/tests/ObjectTypeTest.hack
@@ -1,0 +1,52 @@
+use namespace Slack\GraphQL;
+
+/**
+ * Test GraphQL output objects.
+ */
+final class ObjectTypeTest extends PlaygroundTest {
+
+    <<__Override>>
+    public static function getTestCases(): this::TTestCases {
+        return dict[
+            'select an object generated from a shape' => tuple(
+                'query {
+                    getObjectShape {
+                        foo
+                        bar
+                        baz {
+                            abc
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    'getObjectShape' => dict[
+                        'foo' => 3,
+                        'bar' => null,
+                        'baz' => dict[
+                            'abc' => vec[1, 2, 3]
+                        ]
+                    ],
+                ],
+            ),
+
+            'select a nested shape only' => tuple(
+                'query {
+                    getObjectShape {
+                        baz {
+                            abc
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    'getObjectShape' => dict[
+                        'baz' => dict[
+                            'abc' => vec[1, 2, 3]
+                        ]
+                    ],
+                ],
+            ),
+        ];
+    }
+}

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d382ad6758699cda769585df93eaf28b>>
+ * @generated SignedSource<<d525dfcf31476006f570f0c3036e69c5>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,6 +29,26 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           ErrorTest::nonNullable(),
           async ($parent, $args, $vars) ==> \ErrorTestObj::getNonNullable(),
+        );
+      case 'getConcrete':
+        return new GraphQL\FieldDefinition(
+          Concrete::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
+        );
+      case 'getInterfaceA':
+        return new GraphQL\FieldDefinition(
+          InterfaceA::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
+        );
+      case 'getInterfaceB':
+        return new GraphQL\FieldDefinition(
+          InterfaceB::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
+        );
+      case 'getObjectShape':
+        return new GraphQL\FieldDefinition(
+          ObjectShape::nullable(),
+          async ($parent, $args, $vars) ==> \ObjectTypeTestEntrypoint::getObjectShape(),
         );
       case 'output_type_test':
         return new GraphQL\FieldDefinition(
@@ -82,21 +102,6 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
             CreateUserInput::nonNullable()->coerceNode($args['input']->getValue(), $vars),
           ),
         );
-      case 'getConcrete':
-        return new GraphQL\FieldDefinition(
-          Concrete::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
-        );
-      case 'getInterfaceA':
-        return new GraphQL\FieldDefinition(
-          InterfaceA::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
-        );
-      case 'getInterfaceB':
-        return new GraphQL\FieldDefinition(
-          InterfaceB::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
-        );
       default:
         throw new \Exception('Unknown field: '.$field_name);
     }
@@ -132,34 +137,49 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
   }
 }
 
-final class User extends \Slack\GraphQL\Types\ObjectType {
+final class ObjectShape extends \Slack\GraphQL\Types\ObjectType {
 
-  const type THackType = \User;
-  const NAME = 'User';
+  const type THackType = \ObjectShape;
+  const NAME = 'ObjectShape';
 
   public function getFieldDefinition(
     string $field_name,
   ): GraphQL\IFieldDefinition<this::THackType> {
     switch ($field_name) {
-      case 'id':
+      case 'foo':
         return new GraphQL\FieldDefinition(
           Types\IntOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->getId(),
+          async ($parent, $args, $vars) ==> $parent['foo'],
         );
-      case 'name':
+      case 'bar':
         return new GraphQL\FieldDefinition(
           Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->getName(),
+          async ($parent, $args, $vars) ==> $parent['bar'] ?? null,
         );
-      case 'team':
+      case 'baz':
         return new GraphQL\FieldDefinition(
-          Team::nullable(),
-          async ($parent, $args, $vars) ==> await $parent->getTeam(),
+          AnotherObjectShape::nullable(),
+          async ($parent, $args, $vars) ==> $parent['baz'],
         );
-      case 'is_active':
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
+final class AnotherObjectShape extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \AnotherObjectShape;
+  const NAME = 'AnotherObjectShape';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'abc':
         return new GraphQL\FieldDefinition(
-          Types\BooleanOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->isActive(),
+          Types\IntOutputType::nonNullable()->nullableListOf(),
+          async ($parent, $args, $vars) ==> $parent['abc'],
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -205,6 +225,41 @@ final class InterfaceB extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           Types\StringOutputType::nullable(),
           async ($parent, $args, $vars) ==> $parent->bar(),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
+final class User extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \User;
+  const NAME = 'User';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'id':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->getId(),
+        );
+      case 'name':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->getName(),
+        );
+      case 'team':
+        return new GraphQL\FieldDefinition(
+          Team::nullable(),
+          async ($parent, $args, $vars) ==> await $parent->getTeam(),
+        );
+      case 'is_active':
+        return new GraphQL\FieldDefinition(
+          Types\BooleanOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -280,6 +335,36 @@ final class ErrorTest extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           ErrorTest::nonNullable()->nonNullableListOf(),
           async ($parent, $args, $vars) ==> $parent->nested_list_nn_of_nn(),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
+final class Concrete extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \Concrete;
+  const NAME = 'Concrete';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'foo':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->foo(),
+        );
+      case 'bar':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->bar(),
+        );
+      case 'baz':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->baz(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -454,36 +539,6 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
   }
 }
 
-final class Concrete extends \Slack\GraphQL\Types\ObjectType {
-
-  const type THackType = \Concrete;
-  const NAME = 'Concrete';
-
-  public function getFieldDefinition(
-    string $field_name,
-  ): GraphQL\IFieldDefinition<this::THackType> {
-    switch ($field_name) {
-      case 'foo':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->foo(),
-        );
-      case 'bar':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->bar(),
-        );
-      case 'baz':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->baz(),
-        );
-      default:
-        throw new \Exception('Unknown field: '.$field_name);
-    }
-  }
-}
-
 final class FavoriteColorInputType extends \Slack\GraphQL\Types\EnumInputType {
 
   const NAME = 'FavoriteColor';
@@ -584,6 +639,7 @@ abstract final class Schema extends \Slack\GraphQL\BaseSchema {
     'FavoriteColor' => FavoriteColorInputType::class,
   ];
   const dict<string, classname<Types\NamedOutputType>> OUTPUT_TYPES = dict[
+    'AnotherObjectShape' => AnotherObjectShape::class,
     'Bot' => Bot::class,
     'Concrete' => Concrete::class,
     'ErrorTest' => ErrorTest::class,
@@ -592,6 +648,7 @@ abstract final class Schema extends \Slack\GraphQL\BaseSchema {
     'InterfaceA' => InterfaceA::class,
     'InterfaceB' => InterfaceB::class,
     'Mutation' => Mutation::class,
+    'ObjectShape' => ObjectShape::class,
     'OutputTypeTest' => OutputTypeTest::class,
     'Query' => Query::class,
     'Team' => Team::class,


### PR DESCRIPTION
Implements much of #53 .

We don't yet support descriptions because we don't yet have a use for them. They'll be used by the introspection system at some point (hopefully soon), and we can revisit then.

The generator code is getting increasingly gnarly. This new `OutputObjectType.hack` `GeneratableClass` looks a lot like both the code for `InputObjectType` and `CompositeObject`. We should find some nice way to share code between these types, but I'm punting for now.
