### PR TITLE
codegen dicts of input/output types

### DIFF
--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -3,6 +3,8 @@ namespace Slack\GraphQL;
 // TODO: this should be private
 abstract class BaseSchema {
     const SUPPORTS_MUTATIONS = false;
+    abstract const dict<string, classname<Types\NamedInputType>> INPUT_TYPES;
+    abstract const dict<string, classname<Types\NamedOutputType>> OUTPUT_TYPES;
 
     abstract public static function resolveQuery(
         \Graphpinator\Parser\Operation\Operation $operation,

--- a/src/Codegen/InputObjectType.hack
+++ b/src/Codegen/InputObjectType.hack
@@ -13,6 +13,14 @@ class InputObjectType implements GeneratableClass {
         return $this->input_type->getType();
     }
 
+    public function getInputTypeName(): string {
+        return $this->input_type->getType();
+    }
+
+    public function getOutputTypeName(): null {
+        return null;
+    }
+
     public function generateClass(HackCodegenFactory $cg): CodegenClass {
         $hack_type = $this->reflection_type_alias->getName();
 

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,33 +4,12 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b703dd24fc9dc008cbe3088dace5d168>>
+ * @generated SignedSource<<d382ad6758699cda769585df93eaf28b>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
 use namespace HH\Lib\{C, Dict};
-use namespace Facebook\TypeAssert;
-use namespace Facebook\TypeCoerce;
-
-abstract final class Schema extends \Slack\GraphQL\BaseSchema {
-
-  const bool SUPPORTS_MUTATIONS = true;
-
-  public static async function resolveQuery(
-    \Graphpinator\Parser\Operation\Operation $operation,
-    \Slack\GraphQL\Variables $variables,
-  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
-    return await Query::nullable()->resolveAsync(new GraphQL\Root(), $operation, $variables);
-  }
-
-  public static async function resolveMutation(
-    \Graphpinator\Parser\Operation\Operation $operation,
-    \Slack\GraphQL\Variables $variables,
-  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
-    return await Mutation::nullable()->resolveAsync(new GraphQL\Root(), $operation, $variables);
-  }
-}
 
 final class Query extends \Slack\GraphQL\Types\ObjectType {
 
@@ -594,5 +573,43 @@ final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
       $ret['favorite_color'] = FavoriteColorInputType::nullable()->coerceNamedNode('favorite_color', $fields, $vars);
     }
     return $ret;
+  }
+}
+
+abstract final class Schema extends \Slack\GraphQL\BaseSchema {
+
+  const dict<string, classname<Types\NamedInputType>> INPUT_TYPES = dict[
+    'CreateTeamInput' => CreateTeamInput::class,
+    'CreateUserInput' => CreateUserInput::class,
+    'FavoriteColor' => FavoriteColorInputType::class,
+  ];
+  const dict<string, classname<Types\NamedOutputType>> OUTPUT_TYPES = dict[
+    'Bot' => Bot::class,
+    'Concrete' => Concrete::class,
+    'ErrorTest' => ErrorTest::class,
+    'FavoriteColor' => FavoriteColorOutputType::class,
+    'Human' => Human::class,
+    'InterfaceA' => InterfaceA::class,
+    'InterfaceB' => InterfaceB::class,
+    'Mutation' => Mutation::class,
+    'OutputTypeTest' => OutputTypeTest::class,
+    'Query' => Query::class,
+    'Team' => Team::class,
+    'User' => User::class,
+  ];
+  const bool SUPPORTS_MUTATIONS = true;
+
+  public static async function resolveQuery(
+    \Graphpinator\Parser\Operation\Operation $operation,
+    \Slack\GraphQL\Variables $variables,
+  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
+    return await Query::nullable()->resolveAsync(new GraphQL\Root(), $operation, $variables);
+  }
+
+  public static async function resolveMutation(
+    \Graphpinator\Parser\Operation\Operation $operation,
+    \Slack\GraphQL\Variables $variables,
+  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
+    return await Mutation::nullable()->resolveAsync(new GraphQL\Root(), $operation, $variables);
   }
 }


### PR DESCRIPTION
...so we can use them for introspection, validation, variable coercion, etc.

I made the generics on InputType and OutputType covariant (`+T`) or contravariant (`-T`) as needed. This is so that we can refer to e.g. a list of arbitrary input types as `InputType<mixed>`, which is impossible if the generic type is invariant.