### PR TITLE
coerce variable values before execution

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -313,8 +313,8 @@ final class Generator {
             ->useNamespace('Slack\\GraphQL\\Types')
             ->useNamespace('HH\\Lib\\{C, Dict}');
 
-        $input_types = dict[];
-        $output_types = dict[];
+        $input_types = BUILTIN_INPUT_TYPES;
+        $output_types = BUILTIN_OUTPUT_TYPES;
 
         $has_type_assertions = false;
         foreach ($objects as $object) {
@@ -388,7 +388,11 @@ final class Generator {
     private static function classnameDict(dict<string, string> $dict): string {
         $lines = vec['dict['];
         foreach (Dict\sort_by_key($dict) as $key => $value) {
-            $lines[] = Str\format("  %s => %s::class,", \var_export($key, true), $value);
+            $lines[] = Str\format(
+                "  %s => %s::class,",
+                \var_export($key, true),
+                Str\strip_prefix($value, 'Slack\\GraphQL\\'),
+            );
         }
         $lines[] = ']';
         return Str\join($lines, "\n");

--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -3,6 +3,18 @@ namespace Slack\GraphQL\Codegen;
 use namespace HH\Lib\Str;
 use namespace Slack\GraphQL\Types;
 
+const dict<string, classname<Types\NamedInputType>> BUILTIN_INPUT_TYPES = dict[
+    Types\IntInputType::NAME => Types\IntInputType::class,
+    Types\StringInputType::NAME => Types\StringInputType::class,
+    Types\BooleanInputType::NAME => Types\BooleanInputType::class,
+];
+
+const dict<string, classname<Types\NamedOutputType>> BUILTIN_OUTPUT_TYPES = dict[
+    Types\IntOutputType::NAME => Types\IntOutputType::class,
+    Types\StringOutputType::NAME => Types\StringOutputType::class,
+    Types\BooleanOutputType::NAME => Types\BooleanOutputType::class,
+];
+
 /**
  * Examples:
  *   int       -> IntInputType::nonNullable()

--- a/src/Types/Input/EnumInputType.hack
+++ b/src/Types/Input/EnumInputType.hack
@@ -24,13 +24,6 @@ abstract class EnumInputType extends NamedInputType {
         return $enum::getValues()[$value];
     }
 
-    final protected function assertValidVariableValue(mixed $value): this::TCoerced {
-        // TODO: This should just be $value as this::TCoerced, once variables are properly coerced at the beginning
-        // of execution. Otherwise we'd try (and fail) to coerce an already-coerced value here.
-        $enum = static::HACK_ENUM;
-        return $enum::getValues()[$value as string];
-    }
-
     <<__Override>>
     final public function coerceNonVariableNode(
         Value\Value $node,

--- a/src/Types/Input/InputObjectType.hack
+++ b/src/Types/Input/InputObjectType.hack
@@ -11,10 +11,6 @@ abstract class InputObjectType extends NamedInputType {
     abstract const type TCoerced as shape(...);
     abstract const keyset<string> FIELD_NAMES;
 
-    final protected function assertValidVariableValue(mixed $value): this::TCoerced {
-        return $value as this::TCoerced;
-    }
-
     <<__Override>>
     public function coerceValue(mixed $value): this::TCoerced {
         if (!$value is KeyedContainer<_, _>) {

--- a/src/Types/Input/ListInputType.hack
+++ b/src/Types/Input/ListInputType.hack
@@ -4,7 +4,7 @@ use namespace HH\Lib\Vec;
 use namespace Graphpinator\Parser\Value;
 use type Slack\GraphQL\UserFacingError;
 
-final class ListInputType<TInner> extends InputType<vec<TInner>> {
+final class ListInputType<+TInner> extends InputType<vec<TInner>> {
 
     public function __construct(private InputType<TInner> $innerType) {}
 

--- a/src/Types/Input/NamedInputType.hack
+++ b/src/Types/Input/NamedInputType.hack
@@ -23,7 +23,7 @@ abstract class NamedInputType extends InputType<this::TCoerced> {
     }
 
     <<__Override>>
-    protected function assertValidVariableValue(mixed $value): this::TCoerced {
+    final protected function assertValidVariableValue(mixed $value): this::TCoerced {
         return $value as this::TCoerced;
     }
 

--- a/src/Types/Input/NullableInputType.hack
+++ b/src/Types/Input/NullableInputType.hack
@@ -2,7 +2,7 @@ namespace Slack\GraphQL\Types;
 
 use namespace Graphpinator\Parser\Value;
 
-final class NullableInputType<TInner as nonnull> extends InputType<?TInner> {
+final class NullableInputType<+TInner as nonnull> extends InputType<?TInner> {
 
     public function __construct(private InputType<TInner> $innerType) {}
 

--- a/tests/BasicTest.hack
+++ b/tests/BasicTest.hack
@@ -23,8 +23,13 @@ final class BasicTest extends PlaygroundTest {
                 dict['viewer' => dict['team' => dict['name' => 'Test Team 1', 'num_users' => 3]]],
             ),
             'variables' => tuple(
-                'query TestQuery($user_id: ID!) { user(id: $user_id) { id } }',
+                'query TestQuery($user_id: Int!) { user(id: $user_id) { id } }',
                 dict['user_id' => 3],
+                dict['user' => dict['id' => 3]],
+            ),
+            'variable with default' => tuple(
+                'query TestQuery($user_id: Int! = 3) { user(id: $user_id) { id } }',
+                dict[],
                 dict['user' => dict['id' => 3]],
             ),
             'nested variables' => tuple(
@@ -63,7 +68,7 @@ final class BasicTest extends PlaygroundTest {
                 dict['takes_favorite_color' => true]
             ),
             'enum arguments with variables' => tuple(
-                'query { takes_favorite_color(favorite_color: $favorite_color) }',
+                'query ($favorite_color: FavoriteColor!) { takes_favorite_color(favorite_color: $favorite_color) }',
                 dict['favorite_color' => 'RED'],
                 dict['takes_favorite_color' => true]
             ),

--- a/tests/ErrorTest.hack
+++ b/tests/ErrorTest.hack
@@ -275,7 +275,52 @@ final class ErrorTest extends PlaygroundTest {
                         )
                     ]
                 )
-            )
+            ),
+
+            'missing variable' => tuple(
+                'query ($id: Int!) { user(id: $id) { name } }',
+                dict[],
+                shape(
+                    // Note: No 'data' because variable coercion errors happen before GraphQL execution starts.
+                    'errors' => vec[
+                        shape('message' => 'Missing value for required variable "id"'),
+                    ],
+                ),
+            ),
+
+            'invalid variable value' => tuple(
+                'query ($id: Int!) { user(id: $id) { name } }',
+                dict['id' => 'forty-two'],
+                shape(
+                    'errors' => vec[
+                        shape('message' => 'Invalid value for variable "id": Expected an integer, got forty-two')
+                    ],
+                ),
+            ),
+
+            'invalid variable default' => tuple(
+                'query ($id: Int! = null) { user(id: $id) { name } }',
+                dict[],
+                shape(
+                    'errors' => vec[
+                        shape(
+                            'message' =>
+                                'Invalid default value for variable "id": '.
+                                'Expected an Int literal, got Graphpinator\\Parser\\Value\\Literal',
+                        ),
+                    ],
+                ),
+            ),
+
+            'invalid variable type' => tuple(
+                'query ($id: InvalidType!) { user(id: $id) { name } }',
+                dict[],
+                shape(
+                    'errors' => vec[
+                        shape('message' => 'Undefined input type "InvalidType"'),
+                    ],
+                ),
+            ),
         ];
     }
 }

--- a/tests/InputTypeTest.hack
+++ b/tests/InputTypeTest.hack
@@ -214,7 +214,6 @@ final class InputTypeTest extends PlaygroundTest {
                 dict['optional_field_test' => 'color is null'],
             ),
 
-            /* TODO: doesn't work yet (needs variable coercion)
             'optional input object field (missing variable with default)' => tuple(
                 'query ($color: FavoriteColor = RED) {
                     optional_field_test(input: {name: "foo", favorite_color: $color})
@@ -222,7 +221,6 @@ final class InputTypeTest extends PlaygroundTest {
                 dict[], // no variables
                 dict['optional_field_test' => 'color is non-null'],
             ),
-            */
 
             'optional input object field (null variable with default)' => tuple(
                 'query ($color: FavoriteColor = RED) {

--- a/tests/gen/Generated.hack
+++ b/tests/gen/Generated.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d525dfcf31476006f570f0c3036e69c5>>
+ * @generated SignedSource<<628306589c76b36fe27fb782e5baee0f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -30,30 +30,15 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
           ErrorTest::nonNullable(),
           async ($parent, $args, $vars) ==> \ErrorTestObj::getNonNullable(),
         );
-      case 'getConcrete':
+      case 'output_type_test':
         return new GraphQL\FieldDefinition(
-          Concrete::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
-        );
-      case 'getInterfaceA':
-        return new GraphQL\FieldDefinition(
-          InterfaceA::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
-        );
-      case 'getInterfaceB':
-        return new GraphQL\FieldDefinition(
-          InterfaceB::nullable(),
-          async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
+          OutputTypeTest::nullable(),
+          async ($parent, $args, $vars) ==> \OutputTypeTestObj::get(),
         );
       case 'getObjectShape':
         return new GraphQL\FieldDefinition(
           ObjectShape::nullable(),
           async ($parent, $args, $vars) ==> \ObjectTypeTestEntrypoint::getObjectShape(),
-        );
-      case 'output_type_test':
-        return new GraphQL\FieldDefinition(
-          OutputTypeTest::nullable(),
-          async ($parent, $args, $vars) ==> \OutputTypeTestObj::get(),
         );
       case 'viewer':
         return new GraphQL\FieldDefinition(
@@ -101,6 +86,21 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
           async ($parent, $args, $vars) ==> \UserQueryAttributes::optionalFieldTest(
             CreateUserInput::nonNullable()->coerceNode($args['input']->getValue(), $vars),
           ),
+        );
+      case 'getConcrete':
+        return new GraphQL\FieldDefinition(
+          Concrete::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
+        );
+      case 'getInterfaceA':
+        return new GraphQL\FieldDefinition(
+          InterfaceA::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
+        );
+      case 'getInterfaceB':
+        return new GraphQL\FieldDefinition(
+          InterfaceB::nullable(),
+          async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -187,6 +187,41 @@ final class AnotherObjectShape extends \Slack\GraphQL\Types\ObjectType {
   }
 }
 
+final class User extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \User;
+  const NAME = 'User';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'id':
+        return new GraphQL\FieldDefinition(
+          Types\IntOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->getId(),
+        );
+      case 'name':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->getName(),
+        );
+      case 'team':
+        return new GraphQL\FieldDefinition(
+          Team::nullable(),
+          async ($parent, $args, $vars) ==> await $parent->getTeam(),
+        );
+      case 'is_active':
+        return new GraphQL\FieldDefinition(
+          Types\BooleanOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->isActive(),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
 final class InterfaceA extends \Slack\GraphQL\Types\ObjectType {
 
   const type THackType = \InterfaceA;
@@ -225,41 +260,6 @@ final class InterfaceB extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           Types\StringOutputType::nullable(),
           async ($parent, $args, $vars) ==> $parent->bar(),
-        );
-      default:
-        throw new \Exception('Unknown field: '.$field_name);
-    }
-  }
-}
-
-final class User extends \Slack\GraphQL\Types\ObjectType {
-
-  const type THackType = \User;
-  const NAME = 'User';
-
-  public function getFieldDefinition(
-    string $field_name,
-  ): GraphQL\IFieldDefinition<this::THackType> {
-    switch ($field_name) {
-      case 'id':
-        return new GraphQL\FieldDefinition(
-          Types\IntOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->getId(),
-        );
-      case 'name':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->getName(),
-        );
-      case 'team':
-        return new GraphQL\FieldDefinition(
-          Team::nullable(),
-          async ($parent, $args, $vars) ==> await $parent->getTeam(),
-        );
-      case 'is_active':
-        return new GraphQL\FieldDefinition(
-          Types\BooleanOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -335,36 +335,6 @@ final class ErrorTest extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           ErrorTest::nonNullable()->nonNullableListOf(),
           async ($parent, $args, $vars) ==> $parent->nested_list_nn_of_nn(),
-        );
-      default:
-        throw new \Exception('Unknown field: '.$field_name);
-    }
-  }
-}
-
-final class Concrete extends \Slack\GraphQL\Types\ObjectType {
-
-  const type THackType = \Concrete;
-  const NAME = 'Concrete';
-
-  public function getFieldDefinition(
-    string $field_name,
-  ): GraphQL\IFieldDefinition<this::THackType> {
-    switch ($field_name) {
-      case 'foo':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->foo(),
-        );
-      case 'bar':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->bar(),
-        );
-      case 'baz':
-        return new GraphQL\FieldDefinition(
-          Types\StringOutputType::nullable(),
-          async ($parent, $args, $vars) ==> $parent->baz(),
         );
       default:
         throw new \Exception('Unknown field: '.$field_name);
@@ -539,6 +509,36 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
   }
 }
 
+final class Concrete extends \Slack\GraphQL\Types\ObjectType {
+
+  const type THackType = \Concrete;
+  const NAME = 'Concrete';
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): GraphQL\IFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'foo':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->foo(),
+        );
+      case 'bar':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->bar(),
+        );
+      case 'baz':
+        return new GraphQL\FieldDefinition(
+          Types\StringOutputType::nullable(),
+          async ($parent, $args, $vars) ==> $parent->baz(),
+        );
+      default:
+        throw new \Exception('Unknown field: '.$field_name);
+    }
+  }
+}
+
 final class FavoriteColorInputType extends \Slack\GraphQL\Types\EnumInputType {
 
   const NAME = 'FavoriteColor';
@@ -634,23 +634,29 @@ final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
 abstract final class Schema extends \Slack\GraphQL\BaseSchema {
 
   const dict<string, classname<Types\NamedInputType>> INPUT_TYPES = dict[
+    'Boolean' => Types\BooleanInputType::class,
     'CreateTeamInput' => CreateTeamInput::class,
     'CreateUserInput' => CreateUserInput::class,
     'FavoriteColor' => FavoriteColorInputType::class,
+    'Int' => Types\IntInputType::class,
+    'String' => Types\StringInputType::class,
   ];
   const dict<string, classname<Types\NamedOutputType>> OUTPUT_TYPES = dict[
     'AnotherObjectShape' => AnotherObjectShape::class,
+    'Boolean' => Types\BooleanOutputType::class,
     'Bot' => Bot::class,
     'Concrete' => Concrete::class,
     'ErrorTest' => ErrorTest::class,
     'FavoriteColor' => FavoriteColorOutputType::class,
     'Human' => Human::class,
+    'Int' => Types\IntOutputType::class,
     'InterfaceA' => InterfaceA::class,
     'InterfaceB' => InterfaceB::class,
     'Mutation' => Mutation::class,
     'ObjectShape' => ObjectShape::class,
     'OutputTypeTest' => OutputTypeTest::class,
     'Query' => Query::class,
+    'String' => Types\StringOutputType::class,
     'Team' => Team::class,
     'User' => User::class,
   ];


### PR DESCRIPTION
This should get rid of most of the spurious errors from `assertValidVariableValue()`. They may still happen though (until we have query validation), if a variable is used as the value of a field argument of an incompatible type.

Closes #44