### PR TITLE
type-safe literals

### DIFF
--- a/src/Graphpinator/Parser/Parser.hack
+++ b/src/Graphpinator/Parser/Parser.hack
@@ -432,17 +432,19 @@ final class Parser {
                 return new \Graphpinator\Parser\Value\EnumLiteral($this->tokenizer->getCurrent()->getValue()
                     as nonnull);
             case TokenType::STRING:
-                return new \Graphpinator\Parser\Value\Literal($this->tokenizer->getCurrent()->getValue());
+                return new \Graphpinator\Parser\Value\StringLiteral(
+                    $this->tokenizer->getCurrent()->getValue() as nonnull,
+                );
             case TokenType::INT:
-                return new \Graphpinator\Parser\Value\Literal((int)$this->tokenizer->getCurrent()->getValue());
+                return new \Graphpinator\Parser\Value\IntLiteral((int)$this->tokenizer->getCurrent()->getValue());
             case TokenType::FLOAT:
-                return new \Graphpinator\Parser\Value\Literal((float)$this->tokenizer->getCurrent()->getValue());
+                return new \Graphpinator\Parser\Value\FloatLiteral((float)$this->tokenizer->getCurrent()->getValue());
             case TokenType::TRUE:
-                return new \Graphpinator\Parser\Value\Literal(true);
+                return new \Graphpinator\Parser\Value\BooleanLiteral(true);
             case TokenType::FALSE:
-                return new \Graphpinator\Parser\Value\Literal(false);
+                return new \Graphpinator\Parser\Value\BooleanLiteral(false);
             case TokenType::NULL:
-                return new \Graphpinator\Parser\Value\Literal(null);
+                return new \Graphpinator\Parser\Value\NullLiteral(null);
             case TokenType::SQU_O:
                 $values = vec[];
 

--- a/src/Graphpinator/Parser/Value/BooleanLiteral.hack
+++ b/src/Graphpinator/Parser/Value/BooleanLiteral.hack
@@ -1,0 +1,5 @@
+namespace Graphpinator\Parser\Value;
+
+final class BooleanLiteral extends \Graphpinator\Parser\Value\Literal {
+    const type THackType = bool;
+}

--- a/src/Graphpinator/Parser/Value/FloatLiteral.hack
+++ b/src/Graphpinator/Parser/Value/FloatLiteral.hack
@@ -1,0 +1,5 @@
+namespace Graphpinator\Parser\Value;
+
+final class FloatLiteral extends \Graphpinator\Parser\Value\Literal {
+    const type THackType = float;
+}

--- a/src/Graphpinator/Parser/Value/IntLiteral.hack
+++ b/src/Graphpinator/Parser/Value/IntLiteral.hack
@@ -1,0 +1,5 @@
+namespace Graphpinator\Parser\Value;
+
+final class IntLiteral extends \Graphpinator\Parser\Value\Literal {
+    const type THackType = int;
+}

--- a/src/Graphpinator/Parser/Value/ListVal.hack
+++ b/src/Graphpinator/Parser/Value/ListVal.hack
@@ -8,16 +8,6 @@ final class ListVal implements Value {
         return $this->value;
     }
 
-    public function getRawValue(): vec<mixed> {
-        $return = vec[];
-
-        foreach ($this->value as $value) {
-            $return[] = $value->getRawValue();
-        }
-
-        return $return;
-    }
-
     public function accept(ValueVisitor $valueVisitor): mixed {
         return $valueVisitor->visitListVal($this);
     }

--- a/src/Graphpinator/Parser/Value/Literal.hack
+++ b/src/Graphpinator/Parser/Value/Literal.hack
@@ -1,14 +1,15 @@
 namespace Graphpinator\Parser\Value;
 
-final class Literal implements \Graphpinator\Parser\Value\Value {
+abstract class Literal implements \Graphpinator\Parser\Value\Value {
+    abstract const type THackType;
 
-    public function __construct(private mixed $value) {}
+    final public function __construct(private this::THackType $value) {}
 
-    public function getRawValue(): mixed {
+    final public function getRawValue(): this::THackType {
         return $this->value;
     }
 
-    public function accept(ValueVisitor $valueVisitor): mixed {
+    final public function accept(ValueVisitor $valueVisitor): mixed {
         return $valueVisitor->visitLiteral($this);
     }
 }

--- a/src/Graphpinator/Parser/Value/NullLiteral.hack
+++ b/src/Graphpinator/Parser/Value/NullLiteral.hack
@@ -1,0 +1,5 @@
+namespace Graphpinator\Parser\Value;
+
+final class NullLiteral extends \Graphpinator\Parser\Value\Literal {
+    const type THackType = null;
+}

--- a/src/Graphpinator/Parser/Value/ObjectVal.hack
+++ b/src/Graphpinator/Parser/Value/ObjectVal.hack
@@ -8,16 +8,6 @@ final class ObjectVal implements Value {
         return $this->value;
     }
 
-    public function getRawValue(): dict<string, mixed> {
-        $return = dict[];
-
-        foreach ($this->value as $key => $value) {
-            $return[$key] = $value->getRawValue();
-        }
-
-        return $return;
-    }
-
     public function accept(ValueVisitor $valueVisitor): mixed {
         return $valueVisitor->visitObjectVal($this);
     }

--- a/src/Graphpinator/Parser/Value/StringLiteral.hack
+++ b/src/Graphpinator/Parser/Value/StringLiteral.hack
@@ -1,0 +1,5 @@
+namespace Graphpinator\Parser\Value;
+
+final class StringLiteral extends \Graphpinator\Parser\Value\Literal {
+    const type THackType = string;
+}

--- a/src/Graphpinator/Parser/Value/Value.hack
+++ b/src/Graphpinator/Parser/Value/Value.hack
@@ -1,8 +1,5 @@
 namespace Graphpinator\Parser\Value;
 
 interface Value {
-    // TODO: union: \stdClass|array|string|int|float|bool|null
-    public function getRawValue(): mixed;
-
     public function accept(ValueVisitor $valueVisitor): mixed;
 }

--- a/src/Types/Input/EnumInputType.hack
+++ b/src/Types/Input/EnumInputType.hack
@@ -29,16 +29,17 @@ abstract class EnumInputType extends NamedInputType {
         Value\Value $node,
         dict<string, mixed> $variable_values,
     ): this::THackType {
-        $value = $node->getRawValue();
-        $enum = static::HACK_ENUM;
-        if (!$node is Value\EnumLiteral || !$value is string || !C\contains_key($enum::getValues(), $value)) {
-            throw new GraphQL\UserFacingError(
-                'Expected a valid value for %s, got %s',
-                static::NAME,
-                \get_class($node)
-            );
+        if (!$node is Value\EnumLiteral) {
+            throw new GraphQL\UserFacingError('Expected an enum literal, got %s', \get_class($node));
         }
-        return $enum::getValues()[$value];
+        $enum = static::HACK_ENUM;
+        GraphQL\assert(
+            C\contains_key($enum::getValues(), $node->getRawValue()),
+            'Expected a valid value for %s, got "%s"',
+            static::NAME,
+            $node->getRawValue(),
+        );
+        return $enum::getValues()[$node->getRawValue()];
     }
 
 }

--- a/src/Types/Input/NullableInputType.hack
+++ b/src/Types/Input/NullableInputType.hack
@@ -21,9 +21,7 @@ final class NullableInputType<TInner as nonnull> extends InputType<?TInner> {
         Value\Value $node,
         dict<string, mixed> $variable_values,
     ): ?TInner {
-        return $node is Value\Literal && $node->getRawValue() is null
-            ? null
-            : $this->innerType->coerceNode($node, $variable_values);
+        return $node is Value\NullLiteral ? null : $this->innerType->coerceNode($node, $variable_values);
     }
 
     <<__Override>>

--- a/src/Types/Input/Scalar/BooleanInputType.hack
+++ b/src/Types/Input/Scalar/BooleanInputType.hack
@@ -21,10 +21,9 @@ final class BooleanInputType extends NamedInputType {
         Value\Value $node,
         dict<string, mixed> $variable_values,
     ): bool {
-        $value = $node->getRawValue();
-        if (!$node is Value\Literal || !$value is bool) {
+        if (!$node is Value\BooleanLiteral) {
             throw new GraphQL\UserFacingError('Expected an Boolean literal, got %s', \get_class($node));
         }
-        return $value;
+        return $node->getRawValue();
     }
 }

--- a/src/Types/Input/Scalar/IntInputType.hack
+++ b/src/Types/Input/Scalar/IntInputType.hack
@@ -31,10 +31,14 @@ final class IntInputType extends NamedInputType {
         Value\Value $node,
         dict<string, mixed> $variable_values,
     ): int {
-        $value = $node->getRawValue();
-        if (!$node is Value\Literal || !$value is int) {
+        if (!$node is Value\IntLiteral) {
             throw new GraphQL\UserFacingError('Expected an Int literal, got %s', \get_class($node));
         }
-        return $value;
+        GraphQL\assert(
+            $node->getRawValue() >= self::MIN_SAFE_VALUE && $node->getRawValue() <= self::MAX_SAFE_VALUE,
+            'Integers must be in 32-bit range, got %d',
+            $node->getRawValue(),
+        );
+        return $node->getRawValue();
     }
 }

--- a/src/Types/Input/Scalar/StringInputType.hack
+++ b/src/Types/Input/Scalar/StringInputType.hack
@@ -21,10 +21,9 @@ final class StringInputType extends NamedInputType {
         Value\Value $node,
         dict<string, mixed> $variable_values,
     ): string {
-        $value = $node->getRawValue();
-        if (!$node is Value\Literal || !$value is string) {
+        if (!$node is Value\StringLiteral) {
             throw new UserFacingError('Expected a String literal, got %s', \get_class($node));
         }
-        return $value;
+        return $node->getRawValue();
     }
 }

--- a/tests/ArgumentTest.hack
+++ b/tests/ArgumentTest.hack
@@ -38,7 +38,7 @@ final class ArgumentTest extends PlaygroundTest {
                         shape(
                             'message' =>
                                 'Invalid value for "required": '.
-                                'Expected an Int literal, got Graphpinator\\Parser\\Value\\Literal',
+                                'Expected an Int literal, got Graphpinator\\Parser\\Value\\NullLiteral',
                             'path' => vec['arg_test'],
                         ),
                     ],

--- a/tests/ErrorTest.hack
+++ b/tests/ErrorTest.hack
@@ -256,7 +256,7 @@ final class ErrorTest extends PlaygroundTest {
                         shape(
                             'message' =>
                                 'Invalid value for "favorite_color": '.
-                                'Expected a valid value for FavoriteColor, got Graphpinator\Parser\Value\EnumLiteral',
+                                'Expected a valid value for FavoriteColor, got "foo"',
                             'path' => vec['takes_favorite_color']
                         )
                     ]
@@ -308,7 +308,7 @@ final class ErrorTest extends PlaygroundTest {
                         shape(
                             'message' =>
                                 'Invalid default value for variable "id": '.
-                                'Expected an Int literal, got Graphpinator\\Parser\\Value\\Literal',
+                                'Expected an Int literal, got Graphpinator\\Parser\\Value\\NullLiteral',
                         ),
                     ],
                 ),

--- a/tests/Graphpinator/Parser/ParserTest.hack
+++ b/tests/Graphpinator/Parser/ParserTest.hack
@@ -105,7 +105,8 @@ final class ParserTest extends \Facebook\HackTest\HackTest {
         $arguments = $directives |> C\onlyx($$)->getArguments() as nonnull;
         expect(C\count($arguments))->toBeSame(1);
         expect($arguments)->toContainKey('arg1');
-        expect($arguments['arg1']->getRawValue())->toBeSame(123);
+        expect($arguments['arg1'])->toBeInstanceOf(\Graphpinator\Parser\Value\IntLiteral::class)
+            |> expect($$->getRawValue())->toBeSame(123);
     }
 
     // public function testFragment() : void


### PR DESCRIPTION
Adds parser nodes for `IntLiteral`, `StringLiteral` etc. This makes some of the coercion code simpler and safer, and also improves some of our existing error messages (see updated tests).

I removed `getRawValue()` from `Parser\Value` (only `Literal` values have it now). The method would throw if there is a variable reference nested anywhere inside the literal, which is dangerous and would probably surprise anyone who calls it.