### PR TITLE
Add typechecking to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,10 @@ jobs:
                 docker build -t mwildehahn/hack-graphql .
             - name: Install
               run: |
-                docker run -v `pwd`:/app mwildehahn/hack-graphql composer install
+                docker run -v `pwd`:/app mwildehahn/hack-graphql composer install 
+            - name: Typecheck
+              run: | 
+                docker run -v `pwd`:/app mwildehahn/hack-graphql hh_client
             - name: Test
               run: |
                 docker run -v `pwd`:/app mwildehahn/hack-graphql ./vendor/bin/hacktest tests


### PR DESCRIPTION
Earlier today I pushed a commit with a typechecker error which didn't cause tests to fail (since the runtime code was alright). We shouldn't allow that.