### PR TITLE
Codegen argument defs

### DIFF
--- a/src/Codegen/Builders/Fields/MethodFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/MethodFieldBuilder.hack
@@ -25,7 +25,30 @@ class MethodFieldBuilder implements IFieldBuilder {
         );
         $hb->addLinef('%s,', $type_info['type']);
 
-        // Arguments
+        // Argument Definitions
+        if ($this->hasArguments()) {
+            $hb->addLine('dict[')->indent();
+            foreach ($this->reflection_method->getParameters() as $param) {
+                $argument_name = \var_export($param->getName(), true);
+                $hb->addLinef('%s => shape(', $argument_name)->indent();
+
+                $hb->addLinef("'name' => %s,", $argument_name);
+
+                $type = input_type($param->getTypeText());
+                $hb->addLinef("'type' => %s,", $type);
+
+                if ($param->isOptional()) {
+                    $hb->addLinef("'default_value' => %s,", $param->getDefaultValueText());
+                }
+
+                $hb->unindent()->addLine('),');
+            }
+            $hb->unindent()->addLine('],');
+        } else {
+            $hb->addLine('dict[],');
+        }
+
+        // Resolver
         $hb->addf(
             'async ($parent, $args, $vars) ==> %s%s%s(',
             $type_info['needs_await'] ? 'await ' : '',

--- a/src/Codegen/Builders/Fields/ShapeFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/ShapeFieldBuilder.hack
@@ -18,6 +18,9 @@ class ShapeFieldBuilder<T> implements IFieldBuilder {
         $type_info = output_type(type_structure_to_type_alias($this->type_structure), false);
         $hb->addLinef('%s,', $type_info['type']);
 
+        // Arguments
+        $hb->addLine('dict[],');
+
         $hb->addf(
             'async ($parent, $args, $vars) ==> $parent[%s]%s',
             $name_literal,

--- a/src/FieldDefinition.hack
+++ b/src/FieldDefinition.hack
@@ -1,5 +1,13 @@
 namespace Slack\GraphQL;
 
+type ArgumentDefinition = shape(
+    'name' => string,
+    'type' => Types\IInputType,
+    ?'description' => string,
+    ?'default_value' => mixed,
+    ?'deprecation_reason' => string,
+);
+
 interface IFieldDefinition extends Introspection\__Field {
     public function getName(): string;
     public function getType(): Types\IOutputType;
@@ -17,6 +25,7 @@ final class FieldDefinition<TParent, TRet, TResolved> implements IResolvableFiel
     public function __construct(
         private string $name,
         private Types\OutputType<TRet, TResolved> $type,
+        private dict<string, ArgumentDefinition> $arguments,
         private (function(
             TParent,
             dict<string, \Graphpinator\Parser\Value\Value>,

--- a/tests/gen/AnotherObjectShape.hack
+++ b/tests/gen/AnotherObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<4fc4c226e5a31a8d1d547670a72f7ead>>
+ * @generated SignedSource<<b479ef5b60266684e414b7cd44c3fa9f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -27,6 +27,7 @@ final class AnotherObjectShape extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'abc',
           Types\IntOutputType::nonNullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent['abc'],
         );
       default:

--- a/tests/gen/Bot.hack
+++ b/tests/gen/Bot.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<307495a590faa35a45cea90a748492c4>>
+ * @generated SignedSource<<9d0f0049ff070989f985b504f799a637>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -31,30 +31,35 @@ final class Bot extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'id',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'is_active':
         return new GraphQL\FieldDefinition(
           'is_active',
           Types\BooleanOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'primary_function':
         return new GraphQL\FieldDefinition(
           'primary_function',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getPrimaryFunction(),
         );
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
           Team::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> await $parent->getTeam(),
         );
       default:

--- a/tests/gen/Concrete.hack
+++ b/tests/gen/Concrete.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<f603d37e199485dd330d9957933eaeed>>
+ * @generated SignedSource<<f7d5d48c61338f095fe0bafdd5e5fdf5>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,18 +29,21 @@ final class Concrete extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'bar',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->bar(),
         );
       case 'baz':
         return new GraphQL\FieldDefinition(
           'baz',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->baz(),
         );
       case 'foo':
         return new GraphQL\FieldDefinition(
           'foo',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->foo(),
         );
       default:

--- a/tests/gen/ErrorTestObj.hack
+++ b/tests/gen/ErrorTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b93be60ef4ae05ac3d07adacc732ad8e>>
+ * @generated SignedSource<<fed27872fcb2d3f0635ab4470749cb05>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -38,72 +38,84 @@ final class ErrorTestObj extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'bad_int_list_n_of_n',
           Types\IntOutputType::nullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->bad_int_list_n_of_n(),
         );
       case 'bad_int_list_n_of_nn':
         return new GraphQL\FieldDefinition(
           'bad_int_list_n_of_nn',
           Types\IntOutputType::nonNullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->bad_int_list_n_of_nn(),
         );
       case 'bad_int_list_nn_of_nn':
         return new GraphQL\FieldDefinition(
           'bad_int_list_nn_of_nn',
           Types\IntOutputType::nonNullable()->nonNullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->bad_int_list_nn_of_nn(),
         );
       case 'hidden_exception':
         return new GraphQL\FieldDefinition(
           'hidden_exception',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->hidden_exception(),
         );
       case 'nested':
         return new GraphQL\FieldDefinition(
           'nested',
           ErrorTestObj::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->nested(),
         );
       case 'nested_list_n_of_n':
         return new GraphQL\FieldDefinition(
           'nested_list_n_of_n',
           ErrorTestObj::nullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->nested_list_n_of_n(),
         );
       case 'nested_list_n_of_nn':
         return new GraphQL\FieldDefinition(
           'nested_list_n_of_nn',
           ErrorTestObj::nonNullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->nested_list_n_of_nn(),
         );
       case 'nested_list_nn_of_nn':
         return new GraphQL\FieldDefinition(
           'nested_list_nn_of_nn',
           ErrorTestObj::nonNullable()->nonNullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->nested_list_nn_of_nn(),
         );
       case 'nested_nn':
         return new GraphQL\FieldDefinition(
           'nested_nn',
           ErrorTestObj::nonNullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->nested_nn(),
         );
       case 'no_error':
         return new GraphQL\FieldDefinition(
           'no_error',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->no_error(),
         );
       case 'non_nullable':
         return new GraphQL\FieldDefinition(
           'non_nullable',
           Types\IntOutputType::nonNullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->non_nullable(),
         );
       case 'user_facing_error':
         return new GraphQL\FieldDefinition(
           'user_facing_error',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->user_facing_error(),
         );
       default:

--- a/tests/gen/Human.hack
+++ b/tests/gen/Human.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<1f2132423c60b0da38f568b5fed1706b>>
+ * @generated SignedSource<<eeefd36b61047d6b16af46d2298a9543>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -31,30 +31,35 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'favorite_color',
           FavoriteColorOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getFavoriteColor(),
         );
       case 'id':
         return new GraphQL\FieldDefinition(
           'id',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'is_active':
         return new GraphQL\FieldDefinition(
           'is_active',
           Types\BooleanOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
           Team::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> await $parent->getTeam(),
         );
       default:

--- a/tests/gen/InterfaceA.hack
+++ b/tests/gen/InterfaceA.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<476a19d6b5f407624c5da9604971ab11>>
+ * @generated SignedSource<<7950f22b0bdcf00f0981aaa117996a3d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -27,6 +27,7 @@ final class InterfaceA extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'foo',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->foo(),
         );
       default:

--- a/tests/gen/InterfaceB.hack
+++ b/tests/gen/InterfaceB.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<75658ce23c43ac0321bb86c88616c363>>
+ * @generated SignedSource<<3dc50166a5f92591e4caaebe012a41de>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -28,12 +28,14 @@ final class InterfaceB extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'bar',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->bar(),
         );
       case 'foo':
         return new GraphQL\FieldDefinition(
           'foo',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->foo(),
         );
       default:

--- a/tests/gen/IntrospectionTestObject.hack
+++ b/tests/gen/IntrospectionTestObject.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<17e5cdd7a1f035ac71884e7dcc433c62>>
+ * @generated SignedSource<<6ffb9d87a46456be1434e2cac0a9a4a3>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -33,42 +33,49 @@ final class IntrospectionTestObject extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'default_list_of_non_nullable_int',
           Types\IntOutputType::nonNullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultListOfNonNullableInt(),
         );
       case 'default_list_of_nullable_int':
         return new GraphQL\FieldDefinition(
           'default_list_of_nullable_int',
           Types\IntOutputType::nullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultListOfNullableInt(),
         );
       case 'default_nullable_string':
         return new GraphQL\FieldDefinition(
           'default_nullable_string',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultNullableString(),
         );
       case 'non_null_int':
         return new GraphQL\FieldDefinition(
           'non_null_int',
           Types\IntOutputType::nonNullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getNonNullInt(),
         );
       case 'non_null_list_of_non_null':
         return new GraphQL\FieldDefinition(
           'non_null_list_of_non_null',
           Types\IntOutputType::nonNullable()->nonNullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getNonNullListOfNonNull(),
         );
       case 'non_null_string':
         return new GraphQL\FieldDefinition(
           'non_null_string',
           Types\StringOutputType::nonNullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getNonNullString(),
         );
       case 'nullable_string':
         return new GraphQL\FieldDefinition(
           'nullable_string',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getNullableString(),
         );
       default:

--- a/tests/gen/Mutation.hack
+++ b/tests/gen/Mutation.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<3309c6d72227d932cadde5acacd01cf1>>
+ * @generated SignedSource<<b4322dc52ad290dde837ad2f3c812a6d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -28,6 +28,12 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'createUser',
           User::nullable(),
+          dict[
+            'input' => shape(
+              'name' => 'input',
+              'type' => CreateUserInput::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> await \UserMutationAttributes::createUser(
             CreateUserInput::nonNullable()->coerceNamedNode('input', $args, $vars),
           ),
@@ -36,6 +42,12 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'pokeUser',
           User::nullable(),
+          dict[
+            'id' => shape(
+              'name' => 'id',
+              'type' => Types\IntInputType::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> await \UserMutationAttributes::pokeUser(
             Types\IntInputType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),

--- a/tests/gen/ObjectShape.hack
+++ b/tests/gen/ObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<6a8b945ef4818fbf01e7038407396872>>
+ * @generated SignedSource<<2151e9842debc02eb3d9286bc2f3966f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,18 +29,21 @@ final class ObjectShape extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'foo',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent['foo'],
         );
       case 'bar':
         return new GraphQL\FieldDefinition(
           'bar',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent['bar'] ?? null,
         );
       case 'baz':
         return new GraphQL\FieldDefinition(
           'baz',
           AnotherObjectShape::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent['baz'],
         );
       default:

--- a/tests/gen/OutputTypeTestObj.hack
+++ b/tests/gen/OutputTypeTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<a6e140f1f6d3d3f28a9e4bf591f9cb1c>>
+ * @generated SignedSource<<3e965c545c8823734f324bf821aa4f9c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -33,42 +33,49 @@ final class OutputTypeTestObj extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'awaitable',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> await $parent->awaitable(),
         );
       case 'awaitable_nullable':
         return new GraphQL\FieldDefinition(
           'awaitable_nullable',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> await $parent->awaitable_nullable(),
         );
       case 'awaitable_nullable_list':
         return new GraphQL\FieldDefinition(
           'awaitable_nullable_list',
           Types\IntOutputType::nonNullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> await $parent->awaitable_nullable_list(),
         );
       case 'list':
         return new GraphQL\FieldDefinition(
           'list',
           Types\StringOutputType::nonNullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->list(),
         );
       case 'nested_lists':
         return new GraphQL\FieldDefinition(
           'nested_lists',
           Types\IntOutputType::nullable()->nonNullableListOf()->nullableListOf()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->nested_lists(),
         );
       case 'nullable':
         return new GraphQL\FieldDefinition(
           'nullable',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->nullable(),
         );
       case 'scalar':
         return new GraphQL\FieldDefinition(
           'scalar',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->scalar(),
         );
       default:

--- a/tests/gen/Query.hack
+++ b/tests/gen/Query.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c93b04d3296510b7731e3b79a3922472>>
+ * @generated SignedSource<<212a93b747dc4cfe2c98572af76f6f51>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -45,12 +45,19 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           '__schema',
           __Schema::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \Slack\GraphQL\Introspection\QueryRootFields::getSchema(),
         );
       case '__type':
         return new GraphQL\FieldDefinition(
           '__type',
           __Type::nullable(),
+          dict[
+            'name' => shape(
+              'name' => 'name',
+              'type' => Types\StringInputType::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> \Slack\GraphQL\Introspection\QueryRootFields::getType(
             Types\StringInputType::nonNullable()->coerceNamedNode('name', $args, $vars),
           ),
@@ -59,6 +66,21 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'arg_test',
           Types\IntOutputType::nullable()->nullableListOf(),
+          dict[
+            'required' => shape(
+              'name' => 'required',
+              'type' => Types\IntInputType::nonNullable(),
+            ),
+            'nullable' => shape(
+              'name' => 'nullable',
+              'type' => Types\IntInputType::nullable(),
+            ),
+            'optional' => shape(
+              'name' => 'optional',
+              'type' => Types\IntInputType::nullable(),
+              'default_value' => 42,
+            ),
+          ],
           async ($parent, $args, $vars) ==> \ArgumentTestObj::argTest(
             Types\IntInputType::nonNullable()->coerceNamedNode('required', $args, $vars),
             Types\IntInputType::nullable()->coerceNamedNode('nullable', $args, $vars),
@@ -69,6 +91,12 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'bot',
           Bot::nullable(),
+          dict[
+            'id' => shape(
+              'name' => 'id',
+              'type' => Types\IntInputType::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getBot(
             Types\IntInputType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),
@@ -77,42 +105,54 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'error_test',
           ErrorTestObj::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \ErrorTestObj::get(),
         );
       case 'error_test_nn':
         return new GraphQL\FieldDefinition(
           'error_test_nn',
           ErrorTestObj::nonNullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \ErrorTestObj::getNonNullable(),
         );
       case 'getConcrete':
         return new GraphQL\FieldDefinition(
           'getConcrete',
           Concrete::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
         );
       case 'getInterfaceA':
         return new GraphQL\FieldDefinition(
           'getInterfaceA',
           InterfaceA::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
         );
       case 'getInterfaceB':
         return new GraphQL\FieldDefinition(
           'getInterfaceB',
           InterfaceB::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
         );
       case 'getObjectShape':
         return new GraphQL\FieldDefinition(
           'getObjectShape',
           ObjectShape::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \ObjectTypeTestEntrypoint::getObjectShape(),
         );
       case 'human':
         return new GraphQL\FieldDefinition(
           'human',
           Human::nullable(),
+          dict[
+            'id' => shape(
+              'name' => 'id',
+              'type' => Types\IntInputType::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getHuman(
             Types\IntInputType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),
@@ -121,12 +161,19 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'introspection_test',
           IntrospectionTestObject::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \IntrospectionTestObject::get(),
         );
       case 'list_arg_test':
         return new GraphQL\FieldDefinition(
           'list_arg_test',
           Types\IntOutputType::nonNullable()->nullableListOf()->nullableListOf()->nullableListOf(),
+          dict[
+            'arg' => shape(
+              'name' => 'arg',
+              'type' => Types\IntInputType::nonNullable()->nullableListOf()->nonNullableListOf()->nullableListOf(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> \ArgumentTestObj::listArgTest(
             Types\IntInputType::nonNullable()->nullableListOf()->nonNullableListOf()->nullableListOf()->coerceNamedNode('arg', $args, $vars),
           ),
@@ -135,6 +182,12 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'nested_list_sum',
           Types\IntOutputType::nullable(),
+          dict[
+            'numbers' => shape(
+              'name' => 'numbers',
+              'type' => Types\IntInputType::nonNullable()->nonNullableListOf()->nonNullableListOf(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> \UserQueryAttributes::getNestedListSum(
             Types\IntInputType::nonNullable()->nonNullableListOf()->nonNullableListOf()->coerceNamedNode('numbers', $args, $vars),
           ),
@@ -143,6 +196,12 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'optional_field_test',
           Types\StringOutputType::nullable(),
+          dict[
+            'input' => shape(
+              'name' => 'input',
+              'type' => CreateUserInput::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> \UserQueryAttributes::optionalFieldTest(
             CreateUserInput::nonNullable()->coerceNamedNode('input', $args, $vars),
           ),
@@ -151,12 +210,19 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'output_type_test',
           OutputTypeTestObj::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> \OutputTypeTestObj::get(),
         );
       case 'takes_favorite_color':
         return new GraphQL\FieldDefinition(
           'takes_favorite_color',
           Types\BooleanOutputType::nullable(),
+          dict[
+            'favorite_color' => shape(
+              'name' => 'favorite_color',
+              'type' => FavoriteColorInputType::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> \UserQueryAttributes::takesFavoriteColor(
             FavoriteColorInputType::nonNullable()->coerceNamedNode('favorite_color', $args, $vars),
           ),
@@ -165,6 +231,12 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'user',
           User::nullable(),
+          dict[
+            'id' => shape(
+              'name' => 'id',
+              'type' => Types\IntInputType::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getUser(
             Types\IntInputType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),
@@ -173,6 +245,7 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'viewer',
           User::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getViewer(),
         );
       default:

--- a/tests/gen/Team.hack
+++ b/tests/gen/Team.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<058adec26817cce20b5c51de5eb4d0ca>>
+ * @generated SignedSource<<f68087911dd7d76538007107ef85e6bd>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -30,6 +30,12 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'description',
           Types\StringOutputType::nullable(),
+          dict[
+            'short' => shape(
+              'name' => 'short',
+              'type' => Types\BooleanInputType::nonNullable(),
+            ),
+          ],
           async ($parent, $args, $vars) ==> $parent->getDescription(
             Types\BooleanInputType::nonNullable()->coerceNamedNode('short', $args, $vars),
           ),
@@ -38,18 +44,21 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'id',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'num_users':
         return new GraphQL\FieldDefinition(
           'num_users',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> await $parent->getNumUsers(),
         );
       default:

--- a/tests/gen/User.hack
+++ b/tests/gen/User.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<2cf0ff528404fabaeab51436705748c6>>
+ * @generated SignedSource<<5b97b4a538bdf9c439991d98f7490444>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -30,24 +30,28 @@ final class User extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'id',
           Types\IntOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'is_active':
         return new GraphQL\FieldDefinition(
           'is_active',
           Types\BooleanOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
           Team::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> await $parent->getTeam(),
         );
       default:

--- a/tests/gen/__EnumValue.hack
+++ b/tests/gen/__EnumValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<a3d1b3a9365ce10125c5cf8935b6610d>>
+ * @generated SignedSource<<33fe9e850d1aaaa78fdf0bf5033970f6>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -30,24 +30,28 @@ final class __EnumValue extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'deprecationReason',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDeprecationReason(),
         );
       case 'description':
         return new GraphQL\FieldDefinition(
           'description',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDescription(),
         );
       case 'isDeprecated':
         return new GraphQL\FieldDefinition(
           'isDeprecated',
           Types\BooleanOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->isDeprecated(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       default:

--- a/tests/gen/__Field.hack
+++ b/tests/gen/__Field.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<4f2433b72445f1f4e994240f3359fb1e>>
+ * @generated SignedSource<<6a9207a1322e79be394d367776ac89fb>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -28,12 +28,14 @@ final class __Field extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'type':
         return new GraphQL\FieldDefinition(
           'type',
           __Type::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionType(),
         );
       default:

--- a/tests/gen/__InputValue.hack
+++ b/tests/gen/__InputValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<1582877e83a595ff1ea0f2dc170c0085>>
+ * @generated SignedSource<<9ded20b186d2a8502e79f06d6bd863b0>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -30,24 +30,28 @@ final class __InputValue extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'defaultValue',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultValue(),
         );
       case 'description':
         return new GraphQL\FieldDefinition(
           'description',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDescription(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'type':
         return new GraphQL\FieldDefinition(
           'type',
           __Type::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getType(),
         );
       default:

--- a/tests/gen/__Schema.hack
+++ b/tests/gen/__Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<fc47d9ebed5b24c810478c8aae10067f>>
+ * @generated SignedSource<<8f1f64985a504476bc95a8a86744da68>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -28,12 +28,14 @@ final class __Schema extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'mutationType',
           __Type::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionMutationType(),
         );
       case 'queryType':
         return new GraphQL\FieldDefinition(
           'queryType',
           __Type::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionQueryType(),
         );
       default:

--- a/tests/gen/__Type.hack
+++ b/tests/gen/__Type.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c85a6ed1f6f1c49f4a7e475e7ef77883>>
+ * @generated SignedSource<<f6a3c3d9aea3d8a7180f03a7d77ed3d0>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -31,30 +31,35 @@ final class __Type extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'description',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getDescription(),
         );
       case 'fields':
         return new GraphQL\FieldDefinition(
           'fields',
           __Field::nonNullable()->nullableListOf(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getFields(),
         );
       case 'kind':
         return new GraphQL\FieldDefinition(
           'kind',
           __TypeKindOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getKind(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
           Types\StringOutputType::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'ofType':
         return new GraphQL\FieldDefinition(
           'ofType',
           __Type::nullable(),
+          dict[],
           async ($parent, $args, $vars) ==> $parent->getOfType(),
         );
       default:


### PR DESCRIPTION
Each field definition should know about its parameters. This will be useful for validation and introspection.

For now, we just generate shapes containing the type, name, and default value for each argument. This might get fancier if we need it to.