### PR TITLE
Port KnownTypeNamesRule

### DIFF
--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -3,6 +3,7 @@ namespace Slack\GraphQL;
 use namespace HH\Lib\Dict;
 
 // TODO: this should be private
+<<__ConsistentConstruct>>
 abstract class BaseSchema implements Introspection\__Schema {
     const ?classname<\Slack\GraphQL\Types\ObjectType> MUTATION_TYPE = null;
     abstract const classname<\Slack\GraphQL\Types\ObjectType> QUERY_TYPE;

--- a/src/Graphpinator/Parser/TypeRef/ListTypeRef.hack
+++ b/src/Graphpinator/Parser/TypeRef/ListTypeRef.hack
@@ -1,6 +1,6 @@
 namespace Graphpinator\Parser\TypeRef;
 
-final class ListTypeRef extends \Graphpinator\Parser\Node implements \Graphpinator\Parser\TypeRef\TypeRef {
+final class ListTypeRef extends \Graphpinator\Parser\TypeRef\TypeRef {
 
     public function __construct(\Graphpinator\Common\Location $location, private TypeRef $innerRef) {
         parent::__construct($location);

--- a/src/Graphpinator/Parser/TypeRef/NamedTypeRef.hack
+++ b/src/Graphpinator/Parser/TypeRef/NamedTypeRef.hack
@@ -1,6 +1,6 @@
 namespace Graphpinator\Parser\TypeRef;
 
-final class NamedTypeRef extends \Graphpinator\Parser\Node implements \Graphpinator\Parser\TypeRef\TypeRef {
+final class NamedTypeRef extends \Graphpinator\Parser\TypeRef\TypeRef {
 
     public function __construct(\Graphpinator\Common\Location $location, private string $name) {
         parent::__construct($location);

--- a/src/Graphpinator/Parser/TypeRef/NotNullRef.hack
+++ b/src/Graphpinator/Parser/TypeRef/NotNullRef.hack
@@ -1,6 +1,6 @@
 namespace Graphpinator\Parser\TypeRef;
 
-final class NotNullRef extends \Graphpinator\Parser\Node implements \Graphpinator\Parser\TypeRef\TypeRef {
+final class NotNullRef extends \Graphpinator\Parser\TypeRef\TypeRef {
 
     public function __construct(\Graphpinator\Common\Location $location, private TypeRef $innerRef) {
         parent::__construct($location);

--- a/src/Graphpinator/Parser/TypeRef/TypeRef.hack
+++ b/src/Graphpinator/Parser/TypeRef/TypeRef.hack
@@ -1,5 +1,5 @@
 namespace Graphpinator\Parser\TypeRef;
 
-interface TypeRef {
-    public function print() : string;
+abstract class TypeRef extends \Graphpinator\Parser\Node {
+    abstract public function print(): string;
 }

--- a/src/Validation/Rules/KnownArgumentNamesRule.hack
+++ b/src/Validation/Rules/KnownArgumentNamesRule.hack
@@ -1,6 +1,5 @@
 namespace Slack\GraphQL\Validation;
 
-
 final class KnownArgumentNamesRule extends ValidationRule {
     <<__Override>>
     public function enter(\Graphpinator\Parser\Node $node): void {

--- a/src/Validation/Rules/KnownTypeNamesRule.hack
+++ b/src/Validation/Rules/KnownTypeNamesRule.hack
@@ -1,0 +1,14 @@
+namespace Slack\GraphQL\Validation;
+
+final class KnownTypeNamesRule extends ValidationRule {
+    <<__Override>>
+    public function enter(\Graphpinator\Parser\Node $node): void {
+        if ($node is \Graphpinator\Parser\TypeRef\NamedTypeRef) {
+            $schema = $this->context->getSchema();
+            $type = (new $schema())->getIntrospectionType($node->getName());
+            if ($type is null) {
+                $this->reportError($node, 'Unknown type "%s".', $node->getName());
+            }
+        }
+    }
+}

--- a/src/Validation/Validator.hack
+++ b/src/Validation/Validator.hack
@@ -5,8 +5,9 @@ use type \Slack\GraphQL\__Private\ParallelVisitor;
 
 final class Validator {
     private static keyset<classname<ValidationRule>> $rules = keyset[
-        KnownArgumentNamesRule::class,
         FieldsOnCorrectTypeRule::class,
+        KnownArgumentNamesRule::class,
+        KnownTypeNamesRule::class,
         ScalarLeafsRule::class,
     ];
 

--- a/src/__Private/Visitor/ASTVisitor.hack
+++ b/src/__Private/Visitor/ASTVisitor.hack
@@ -96,8 +96,17 @@ abstract class ASTVisitor {
 
     private function visitVariable(Parser\Variable\Variable $node): void {
         $this->enter($node);
+        $this->visitTypeRef($node->getType());
         foreach ($node->getDirectives() as $directive) {
             // TODO: Directives
+        }
+        $this->leave($node);
+    }
+
+    private function visitTypeRef(Parser\TypeRef\TypeRef $node): void {
+        $this->enter($node);
+        if ($node is Parser\TypeRef\NotNullRef || $node is Parser\TypeRef\ListTypeRef) {
+            $this->visitTypeRef($node->getInnerRef());
         }
         $this->leave($node);
     }

--- a/tests/ErrorTest.hack
+++ b/tests/ErrorTest.hack
@@ -317,7 +317,10 @@ final class ErrorTest extends PlaygroundTest {
                 dict[],
                 shape(
                     'errors' => vec[
-                        shape('message' => 'Undefined input type "InvalidType"'),
+                        shape(
+                            'message' => 'Unknown type "InvalidType".',
+                            'location' => shape('line' => 1, 'column' => 13),
+                        ),
                     ],
                 ),
             ),

--- a/tests/Validation/KnownTypeNamesRuleTest.hack
+++ b/tests/Validation/KnownTypeNamesRuleTest.hack
@@ -1,0 +1,40 @@
+use namespace Slack\GraphQL;
+
+final class KnownTypeNamesRuleTest extends BaseValidationTest {
+    public static function getTestCases(): this::TTestCases {
+        return dict[
+            'known type names are valid' => tuple(
+                'query Foo(
+                    $id: Int!
+                    $is_active: Boolean!
+                    $favorite_color: FavoriteColor!
+                ) {
+                    user(id: $id) {
+                        name
+                    }
+                    takes_favorite_color(favorite_color: $favorite_color)
+                }',
+                vec[],
+            ),
+
+            'unknown type names are invalid' => tuple(
+                'query Foo(
+                    $id: Int!
+                    $is_active: Boolean!
+                    $favorite_color: JumbledUpLetters!
+                ) {
+                    user(id: $id) {
+                        name
+                    }
+                    takes_favorite_color(favorite_color: $favorite_color)
+                }',
+                vec[
+                    shape(
+                        'message' => 'Unknown type "JumbledUpLetters".',
+                        'location' => shape('line' => 4, 'column' => 38),
+                    )
+                ]
+            )
+        ];
+    }
+}


### PR DESCRIPTION
Port [KnownTypeNamesRule](https://github.com/graphql/graphql-js/blob/main/src/validation/rules/KnownTypeNamesRule.js).

We don't handle SDL validation because we'd like to that separately during codegen.