### PR TITLE
Support `possibleTypes` introspection for interfaces

### DIFF
--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -1,16 +1,16 @@
 namespace Slack\GraphQL;
 
-use namespace HH\Lib\Dict;
+use namespace HH\Lib\{Dict, Vec, Str};
 
 // TODO: this should be private
 <<__ConsistentConstruct>>
-abstract class BaseSchema implements Introspection\__Schema {
+abstract class BaseSchema implements Introspection\__Schema, \HH\IMemoizeParam {
     const ?classname<\Slack\GraphQL\Types\ObjectType> MUTATION_TYPE = null;
     abstract const classname<\Slack\GraphQL\Types\ObjectType> QUERY_TYPE;
 
     abstract const dict<string, classname<Types\NamedType>> TYPES;
 
-    abstract public static function resolveQuery(
+    abstract public function resolveQuery(
         \Graphpinator\Parser\Operation\Operation $operation,
         Variables $variables,
     ): Awaitable<ValidFieldResult<?dict<string, mixed>>>;
@@ -19,39 +19,41 @@ abstract class BaseSchema implements Introspection\__Schema {
     * Mutations are optional, if the schema supports it, this method will be
     * overwritten in the generated class.
     */
-    public static async function resolveMutation(
+    public async function resolveMutation(
         \Graphpinator\Parser\Operation\Operation $operation,
         Variables $variables,
     ): Awaitable<ValidFieldResult<?dict<string, mixed>>> {
         return new ValidFieldResult(null);
     }
 
-    final public static function getQueryType(): Types\ObjectType {
+    final public function getQueryType(): Types\ObjectType {
         $query_type = static::QUERY_TYPE;
-        return $query_type::nonNullable();
+        return $query_type::nonNullable($this);
     }
 
-    final public static function getMutationType(): ?Types\ObjectType {
+    final public function getMutationType(): ?Types\ObjectType {
         $mutation_type = static::MUTATION_TYPE;
-        return $mutation_type is nonnull ? $mutation_type::nonNullable() : null;
+        return $mutation_type is nonnull ? $mutation_type::nonNullable($this) : null;
     }
 
     <<__Override>>
     final public function getIntrospectionQueryType(): Introspection\__Type {
         $query_type = static::QUERY_TYPE;
-        return $query_type::nullableOutput();
+        return $query_type::nullableOutput($this);
     }
 
     <<__Override>>
     final public function getIntrospectionMutationType(): ?Introspection\__Type {
         $mutation_type = static::MUTATION_TYPE;
-        return $mutation_type is nonnull ? $mutation_type::nullableOutput() : null;
+        return $mutation_type is nonnull ? $mutation_type::nullableOutput($this) : null;
     }
 
     final public function getIntrospectionType(string $name): ?Introspection\__Type {
         $type = static::TYPES[$name] ?? null;
-        return $type is nonnull ? $type::nonNullable()->nullableForIntrospection() : null;
+        return $type is nonnull ? $type::nonNullable($this)->nullableForIntrospection() : null;
     }
 
-    // TODO add method to create singleton
+    final public function getInstanceKey(): string {
+        return Vec\keys(static::TYPES) |> Str\join($$, '');
+    }
 }

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -102,10 +102,7 @@ final class Generator {
         return $dict;
     }
 
-    private function generateSchemaType(
-        HackCodegenFactory $cg,
-        dict<string, string> $types,
-    ): CodegenClass {
+    private function generateSchemaType(HackCodegenFactory $cg, dict<string, string> $types): CodegenClass {
         $class = $cg->codegenClass('Schema')
             ->setIsFinal(true)
             ->setExtendsf('\%s', \Slack\GraphQL\BaseSchema::class)
@@ -161,11 +158,11 @@ final class Generator {
         switch ($operation_type) {
             case \Graphpinator\Tokenizer\OperationType::QUERY:
                 $method_name = 'resolveQuery';
-                $root_type = 'Query::nullableOutput()';
+                $root_type = 'Query::nullableOutput($this)';
                 break;
             case \Graphpinator\Tokenizer\OperationType::MUTATION:
                 $method_name = 'resolveMutation';
-                $root_type = 'Mutation::nullableOutput()';
+                $root_type = 'Mutation::nullableOutput($this)';
                 break;
             case \Graphpinator\Tokenizer\OperationType::SUBSCRIPTION:
                 invariant(false, 'TODO: support subscription');
@@ -173,7 +170,6 @@ final class Generator {
 
         $resolve_method = $cg->codegenMethod($method_name)
             ->setPublic()
-            ->setIsStatic(true)
             ->setIsAsync(true)
             ->setReturnType('Awaitable<GraphQL\\ValidFieldResult<?dict<string, mixed>>>')
             ->addParameterf('\%s $operation', \Graphpinator\Parser\Operation\Operation::class)

--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -32,7 +32,8 @@ function input_type(string $hack_type): string {
             if ($class is null) {
                 throw new \Error(
                     'GraphQL\Field argument types must be scalar or be enums/input objects annnotated with a GraphQL '.
-                    'attribute, got '.$unwrapped,
+                    'attribute, got '.
+                    $unwrapped,
                 );
             }
     }
@@ -158,7 +159,7 @@ function unwrap_type(IO $io, string $hack_type, bool $nullable = false): (string
         );
         return tuple($unwrapped, $suffix.($nullable ? '->nullable'.$io.'ListOf()' : '->nonNullable'.$io.'ListOf()'));
     }
-    return tuple($hack_type, $nullable ? '::nullable'.$io.'()' : '::nonNullable()');
+    return tuple($hack_type, $nullable ? '::nullable'.$io.'($this->schema)' : '::nonNullable($this->schema)');
 }
 
 enum IO: string as string {
@@ -185,7 +186,7 @@ function type_structure_to_type_alias<T>(TypeStructure<T> $ts): string {
         case TypeStructureKind::OF_VEC:
             return Str\format('HH\vec<%s>', type_structure_to_type_alias($ts['generic_types'] as nonnull[0]));
         case TypeStructureKind::OF_ENUM:
-        //case TypeStructureKind::OF_UNRESOLVED: // not sure if this is needed
+            //case TypeStructureKind::OF_UNRESOLVED: // not sure if this is needed
             return $ts['classname'] as nonnull;
         default:
             invariant_violation(

--- a/src/Introspection/__Type.hack
+++ b/src/Introspection/__Type.hack
@@ -15,23 +15,25 @@ interface __Type {
     <<GraphQL\Field('name', 'Name of the type')>>
     public function getIntrospectionName(): ?string;
 
-    // TODO:
-
+    // TODO: description
     <<GraphQL\Field('description', 'Description of the type')>>
     public function getIntrospectionDescription(): ?string;
 
     <<GraphQL\Field('fields', 'Fields of the type, only applies to OBJECT and INTERFACE')>>
     public function getIntrospectionFields(bool $include_deprecated = false): ?vec<__Field>;
 
+    // TODO: interfaces
     <<GraphQL\Field('interfaces', 'Interfaces the object implements, only applies to OBJECT')>>
     public function getIntrospectionInterfaces(): ?vec<__Type>;
 
     <<GraphQL\Field('possibleTypes', 'Possible types that implement this interface, only applies to INTERFACE')>>
     public function getIntrospectionPossibleTypes(): ?vec<__Type>;
 
+    // TODO: enumValues
     <<GraphQL\Field('enumValues', 'Enum values, only applies to ENUM')>>
     public function getIntrospectionEnumValues(bool $include_deprecated = false): ?vec<__EnumValue>;
 
+    // TODO: inputFields
     <<GraphQL\Field('inputFields', 'Input fields, only applies to INPUT_OBJECT')>>
     public function getIntrospectionInputFields(bool $include_deprecated = false): ?vec<__InputValue>;
 

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -14,7 +14,7 @@ final class Resolver {
         ?'extensions' => dict<string, mixed>,
     );
 
-    public function __construct(private classname<BaseSchema> $schema) {}
+    public function __construct(private BaseSchema $schema) {}
 
     /**
      * Operation name must be specified if the GraphQL request contains multiple operations.
@@ -100,11 +100,11 @@ final class Resolver {
         $operation_type = $operation->getType();
         switch ($operation_type) {
             case 'query':
-                $result = await $schema::resolveQuery($operation, $coerced_variables);
+                $result = await $schema->resolveQuery($operation, $coerced_variables);
                 break;
             case 'mutation':
                 invariant($schema::MUTATION_TYPE, 'mutation operation not supported for schema');
-                $result = await $schema::resolveMutation($operation, $coerced_variables);
+                $result = await $schema->resolveMutation($operation, $coerced_variables);
                 break;
             default:
                 throw new \Error('Unsupported operation: '.$operation_type);

--- a/src/Types/BaseType.hack
+++ b/src/Types/BaseType.hack
@@ -3,5 +3,6 @@ namespace Slack\GraphQL\Types;
 use namespace Slack\GraphQL;
 
 abstract class BaseType implements GraphQL\Introspection\__Type {
+    public function __construct(protected GraphQL\BaseSchema $schema) {}
     abstract public function unwrapType(): NamedType;
 }

--- a/src/Types/Input/InputType.hack
+++ b/src/Types/Input/InputType.hack
@@ -68,8 +68,7 @@ interface IInputTypeFor<THackType> extends IInputType {
     public function nullableInputListOf(): NullableInputType<vec<THackType>>;
 }
 
-interface INonNullableInputTypeFor<THackType as nonnull>
-    extends INonNullableType, IInputTypeFor<THackType> {}
+interface INonNullableInputTypeFor<THackType as nonnull> extends INonNullableType, IInputTypeFor<THackType> {}
 
 trait TInputType<THackType> implements IInputTypeFor<THackType> {
 
@@ -84,10 +83,7 @@ trait TInputType<THackType> implements IInputTypeFor<THackType> {
         dict<string, mixed> $variable_values,
     ): THackType;
 
-    final public function coerceNamedValue(
-        string $name,
-        KeyedContainer<arraykey, mixed> $values,
-    ): THackType {
+    final public function coerceNamedValue(string $name, KeyedContainer<arraykey, mixed> $values): THackType {
         try {
             return $this->coerceValue(idx($values, $name));
         } catch (GraphQL\UserFacingError $e) {
@@ -170,7 +166,7 @@ trait TInputType<THackType> implements IInputTypeFor<THackType> {
      * Convert a parser node (e.g. from a variable declaration) to an instance of the input type it represents.
      */
     public static function fromNode(
-        classname<GraphQL\BaseSchema> $schema,
+        GraphQL\BaseSchema $schema,
         TypeRef\TypeRef $node,
         bool $nullable = true,
     ): IInputType {
@@ -186,10 +182,10 @@ trait TInputType<THackType> implements IInputTypeFor<THackType> {
         if ($class is null) {
             throw new GraphQL\UserFacingError('Undefined type "%s"', $name);
         }
-        $non_nullable = $class::nonNullable();
+        $non_nullable = $class::nonNullable($schema);
         if (!$non_nullable is INamedInputType) {
             throw new GraphQL\UserFacingError('Type "%s" is not an input type', $name);
         }
-        return $nullable ? $non_nullable::nullableInput() : $non_nullable;
+        return $nullable ? $non_nullable::nullableInput($schema) : $non_nullable;
     }
 }

--- a/src/Types/Input/ListInputType.hack
+++ b/src/Types/Input/ListInputType.hack
@@ -9,7 +9,9 @@ final class ListInputType<TInner> extends BaseType implements INonNullableInputT
     use TNonNullableType;
     use TInputType<vec<TInner>>;
 
-    public function __construct(private IInputTypeFor<TInner> $inner_type) {}
+    public function __construct(private IInputTypeFor<TInner> $inner_type) {
+        parent::__construct($inner_type->schema);
+    }
 
     <<__Override>>
     public function unwrapType(): INamedInputType {

--- a/src/Types/Input/NamedInputType.hack
+++ b/src/Types/Input/NamedInputType.hack
@@ -1,5 +1,7 @@
 namespace Slack\GraphQL\Types;
 
+use namespace Slack\GraphQL;
+
 /**
  * Named type is any non-wrapping type.
  *
@@ -14,7 +16,7 @@ interface INamedInputType extends INonNullableInputTypeFor<this::THackType> {
     <<__Enforceable>>
     abstract const type THackType as nonnull;
 
-    public static function nullableInput(): NullableInputType<this::THackType>;
+    public static function nullableInput(GraphQL\BaseSchema $_): NullableInputType<this::THackType>;
 }
 
 <<__ConsistentConstruct>>
@@ -27,12 +29,12 @@ trait TNamedInputType implements INamedInputType {
     }
 
     <<__Override, __MemoizeLSB>>
-    final public static function nullableInput(): NullableInputType<this::THackType> {
-        return new NullableInputType(static::nonNullable());
+    final public static function nullableInput(GraphQL\BaseSchema $schema): NullableInputType<this::THackType> {
+        return new NullableInputType(static::nonNullable($schema));
     }
 
     <<__Override>>
     public function nullableForIntrospection(): INullableType {
-        return static::nullableInput();
+        return static::nullableInput($this->schema);
     }
 }

--- a/src/Types/Input/NullableInputType.hack
+++ b/src/Types/Input/NullableInputType.hack
@@ -7,7 +7,9 @@ final class NullableInputType<TInner as nonnull> extends BaseType {
     use TNullableType;
     use TInputType<?TInner>;
 
-    public function __construct(private INonNullableInputTypeFor<TInner> $inner_type) {}
+    public function __construct(private INonNullableInputTypeFor<TInner> $inner_type) {
+        parent::__construct($inner_type->schema);
+    }
 
     public function getInnerType(): INonNullableInputTypeFor<TInner> {
         return $this->inner_type;

--- a/src/Types/InputOutput/LeafType.hack
+++ b/src/Types/InputOutput/LeafType.hack
@@ -32,6 +32,6 @@ abstract class LeafType extends NamedType {
      */
     <<__Override>>
     final public function nullableForIntrospection(): INullableType {
-        return static::nullableInput();
+        return static::nullableInput($this->schema);
     }
 }

--- a/src/Types/NamedType.hack
+++ b/src/Types/NamedType.hack
@@ -8,8 +8,6 @@ abstract class NamedType extends BaseType implements INonNullableType {
     abstract const type THackType as nonnull;
     abstract const string NAME;
 
-    final private function __construct() {}
-
     <<__Override>>
     final public function getName(): string {
         return static::NAME;
@@ -21,7 +19,7 @@ abstract class NamedType extends BaseType implements INonNullableType {
     }
 
     <<__MemoizeLSB>>
-    final public static function nonNullable(): this {
-        return new static();
+    final public static function nonNullable(GraphQL\BaseSchema $schema): this {
+        return new static($schema);
     }
 }

--- a/src/Types/Output/InterfaceType.hack
+++ b/src/Types/Output/InterfaceType.hack
@@ -13,7 +13,6 @@ abstract class InterfaceType extends CompositeType {
 
     <<__Override>>
     final public function getPossibleTypes(): vec<GraphQL\Introspection\__Type> {
-        return Vec\map(static::POSSIBLE_TYPES, $type ==> $this->schema->getIntrospectionType($type))
-            |> Vec\filter_nulls($$);
+        return Vec\map(static::POSSIBLE_TYPES, $type ==> $this->schema->getIntrospectionType($type) as nonnull);
     }
 }

--- a/src/Types/Output/InterfaceType.hack
+++ b/src/Types/Output/InterfaceType.hack
@@ -4,9 +4,16 @@ use namespace HH\Lib\{Dict, Vec};
 use namespace Slack\GraphQL;
 
 abstract class InterfaceType extends CompositeType {
+    abstract const keyset<string> POSSIBLE_TYPES;
 
     <<__Override>>
     final public function getKind(): GraphQL\Introspection\__TypeKind {
         return GraphQL\Introspection\__TypeKind::INTERFACE;
+    }
+
+    <<__Override>>
+    final public function getPossibleTypes(): vec<GraphQL\Introspection\__Type> {
+        return Vec\map(static::POSSIBLE_TYPES, $type ==> $this->schema->getIntrospectionType($type))
+            |> Vec\filter_nulls($$);
     }
 }

--- a/src/Types/Output/ListOutputType.hack
+++ b/src/Types/Output/ListOutputType.hack
@@ -10,7 +10,9 @@ final class ListOutputType<TInner, TResolved>
     use TNonNullableType;
     use TOutputType<vec<TInner>, vec<mixed>>;
 
-    public function __construct(private IOutputTypeFor<TInner, TResolved> $inner_type) {}
+    public function __construct(private IOutputTypeFor<TInner, TResolved> $inner_type) {
+        parent::__construct($inner_type->schema);
+    }
 
     <<__Override>>
     public function unwrapType(): INamedOutputType {

--- a/src/Types/Output/NamedOutputType.hack
+++ b/src/Types/Output/NamedOutputType.hack
@@ -1,5 +1,7 @@
 namespace Slack\GraphQL\Types;
 
+use namespace Slack\GraphQL;
+
 /**
  * Named type is any non-wrapping type.
  *
@@ -11,7 +13,7 @@ namespace Slack\GraphQL\Types;
 interface INamedOutputType extends INonNullableOutputTypeFor<this::THackType, this::TResolved> {
     require extends NamedType;
     abstract const type TResolved;
-    public static function nullableOutput(): NullableOutputType<this::THackType, this::TResolved>;
+    public static function nullableOutput(GraphQL\BaseSchema $_): NullableOutputType<this::THackType, this::TResolved>;
 }
 
 <<__ConsistentConstruct>>
@@ -19,12 +21,14 @@ trait TNamedOutputType implements INamedOutputType {
     use TOutputType<this::THackType, this::TResolved>;
 
     <<__MemoizeLSB>>
-    final public static function nullableOutput(): NullableOutputType<this::THackType, this::TResolved> {
-        return new NullableOutputType(static::nonNullable());
+    final public static function nullableOutput(
+        GraphQL\BaseSchema $schema,
+    ): NullableOutputType<this::THackType, this::TResolved> {
+        return new NullableOutputType(static::nonNullable($schema));
     }
 
     <<__Override>>
     public function nullableForIntrospection(): INullableType {
-        return static::nullableOutput();
+        return static::nullableOutput($this->schema);
     }
 }

--- a/src/Types/Output/NullableOutputType.hack
+++ b/src/Types/Output/NullableOutputType.hack
@@ -5,7 +5,9 @@ final class NullableOutputType<TInner as nonnull, TResolved> extends BaseType {
     use TNullableType;
     use TOutputType<?TInner, ?TResolved>;
 
-    public function __construct(private INonNullableOutputTypeFor<TInner, TResolved> $inner_type) {}
+    public function __construct(private INonNullableOutputTypeFor<TInner, TResolved> $inner_type) {
+        parent::__construct($inner_type->schema);
+    }
 
     public function getInnerType(): INonNullableOutputTypeFor<TInner, TResolved> {
         return $this->inner_type;

--- a/src/Validation/Rules/KnownTypeNamesRule.hack
+++ b/src/Validation/Rules/KnownTypeNamesRule.hack
@@ -4,8 +4,7 @@ final class KnownTypeNamesRule extends ValidationRule {
     <<__Override>>
     public function enter(\Graphpinator\Parser\Node $node): void {
         if ($node is \Graphpinator\Parser\TypeRef\NamedTypeRef) {
-            $schema = $this->context->getSchema();
-            $type = (new $schema())->getIntrospectionType($node->getName());
+            $type = $this->context->getSchema()->getIntrospectionType($node->getName());
             if ($type is null) {
                 $this->reportError($node, 'Unknown type "%s".', $node->getName());
             }

--- a/src/Validation/TypeInfo.hack
+++ b/src/Validation/TypeInfo.hack
@@ -16,7 +16,7 @@ use type \Slack\GraphQL\__Private\Utils\Stack;
  */
 final class TypeInfo extends ASTVisitor {
 
-    private classname<\Slack\GraphQL\BaseSchema> $schema;
+    private \Slack\GraphQL\BaseSchema $schema;
     private Stack<?Types\IOutputType> $type_stack;
     private Stack<?Types\INamedOutputType> $parent_type_stack;
     private Stack<?Types\IInputType> $input_type_stack;
@@ -24,7 +24,7 @@ final class TypeInfo extends ASTVisitor {
     private Stack<mixed> $default_value_stack;
     private ?\Slack\GraphQL\ArgumentDefinition $argument = null;
 
-    public function __construct(classname<\Slack\GraphQL\BaseSchema> $schema) {
+    public function __construct(\Slack\GraphQL\BaseSchema $schema) {
         $this->schema = $schema;
         $this->type_stack = new Stack();
         $this->parent_type_stack = new Stack();
@@ -82,10 +82,10 @@ final class TypeInfo extends ASTVisitor {
             $schema = $this->schema;
             switch ($node->getType()) {
                 case \Graphpinator\Tokenizer\OperationType::QUERY:
-                    $type = $schema::getQueryType();
+                    $type = $schema->getQueryType();
                     break;
                 case \Graphpinator\Tokenizer\OperationType::MUTATION:
-                    $type = $schema::getMutationType();
+                    $type = $schema->getMutationType();
                     break;
                 default:
                     // TODO: Subscriptions

--- a/src/Validation/ValidationContext.hack
+++ b/src/Validation/ValidationContext.hack
@@ -8,7 +8,7 @@ final class ValidationContext {
     private vec<\Slack\GraphQL\UserFacingError> $errors = vec[];
 
     public function __construct(
-        private classname<\Slack\GraphQL\BaseSchema> $schema,
+        private \Slack\GraphQL\BaseSchema $schema,
         // TODO: Pass in parsed AST as well as rules may need it.
         private TypeInfo $type_info,
     ) {}
@@ -28,7 +28,7 @@ final class ValidationContext {
         return $this->errors;
     }
 
-    public function getSchema(): classname<\Slack\GraphQL\BaseSchema> {
+    public function getSchema(): \Slack\GraphQL\BaseSchema {
         return $this->schema;
     }
 

--- a/src/Validation/Validator.hack
+++ b/src/Validation/Validator.hack
@@ -11,7 +11,7 @@ final class Validator {
         ScalarLeafsRule::class,
     ];
 
-    public function __construct(private classname<\Slack\GraphQL\BaseSchema> $schema) {}
+    public function __construct(private \Slack\GraphQL\BaseSchema $schema) {}
 
     public function validate(\Graphpinator\Parser\ParsedRequest $request): vec<\Slack\GraphQL\UserFacingError> {
         $type_info = new TypeInfo($this->schema);

--- a/src/playground/IntrospectionTestObjects.hack
+++ b/src/playground/IntrospectionTestObjects.hack
@@ -1,5 +1,20 @@
 use namespace Slack\GraphQL;
 
+<<GraphQL\InterfaceType('IIntrospectionInterfaceA', 'IIntrospectionInterfaceA')>>
+interface IIntrospectionInterfaceA {}
+
+<<GraphQL\InterfaceType('IIntrospectionInterfaceB', 'IIntrospectionInterfaceB')>>
+interface IIntrospectionInterfaceB extends IIntrospectionInterfaceA {}
+
+<<GraphQL\InterfaceType('IIntrospectionInterfaceC', 'IIntrospectionInterfaceC')>>
+interface IIntrospectionInterfaceC extends IIntrospectionInterfaceB {}
+
+<<GraphQL\ObjectType('ImplementInterfaceB', 'ImplementInterfaceB')>>
+final class ImplementInterfaceB implements IIntrospectionInterfaceB {}
+
+<<GraphQL\ObjectType('ImplementInterfaceC', 'ImplementInterfaceC')>>
+final class ImplementInterfaceC implements IIntrospectionInterfaceB, IIntrospectionInterfaceC {}
+
 <<GraphQL\ObjectType('IntrospectionTestObject', 'Test object for introspection')>>
 final class IntrospectionTestObject {
 

--- a/tests/IntrospectionTest.hack
+++ b/tests/IntrospectionTest.hack
@@ -8,6 +8,47 @@ final class IntrospectionTest extends PlaygroundTest {
     <<__Override>>
     public static function getTestCases(): this::TTestCases {
         return dict[
+            'validate interface introspection' => tuple(
+                '{
+                    __type(name: "IIntrospectionInterfaceA") {
+                        possibleTypes {
+                            name
+                        }
+                    }
+                 }',
+                dict[],
+                dict[
+                    '__type' => dict[
+                        'possibleTypes' => vec[
+                            dict[
+                                'name' => 'ImplementInterfaceB',
+                            ],
+                            dict[
+                                'name' => 'ImplementInterfaceC',
+                            ],
+                        ],
+                    ],
+                ],
+            ),
+            'validate interface introspection' => tuple(
+                '{
+                    __type(name: "IIntrospectionInterfaceC") {
+                        possibleTypes {
+                            name
+                        }
+                    }
+                 }',
+                dict[],
+                dict[
+                    '__type' => dict[
+                        'possibleTypes' => vec[
+                            dict[
+                                'name' => 'ImplementInterfaceC',
+                            ],
+                        ],
+                    ],
+                ],
+            ),
             'select the name of the query type' => tuple(
                 '{
                     __schema {

--- a/tests/IntrospectionTest.hack
+++ b/tests/IntrospectionTest.hack
@@ -8,7 +8,7 @@ final class IntrospectionTest extends PlaygroundTest {
     <<__Override>>
     public static function getTestCases(): this::TTestCases {
         return dict[
-            'validate interface introspection' => tuple(
+            'validate interface introspection with extended interface' => tuple(
                 '{
                     __type(name: "IIntrospectionInterfaceA") {
                         possibleTypes {

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -42,7 +42,7 @@ abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
     }
 
     private function getResolver(): GraphQL\Resolver {
-        return new GraphQL\Resolver(\Slack\GraphQL\Test\Generated\Schema::class);
+        return new GraphQL\Resolver(new \Slack\GraphQL\Test\Generated\Schema());
     }
 
     public async function resolve(

--- a/tests/Validation/BaseValidationTest.hack
+++ b/tests/Validation/BaseValidationTest.hack
@@ -28,7 +28,7 @@ abstract class BaseValidationTest extends \Facebook\HackTest\HackTest {
         $parser = new \Graphpinator\Parser\Parser($source);
         $request = $parser->parse();
 
-        $validator = new GraphQL\Validation\Validator(GraphQL\Test\Generated\Schema::class);
+        $validator = new GraphQL\Validation\Validator(new GraphQL\Test\Generated\Schema());
         $errors = $validator->validate($request);
         expect(Vec\map($errors, $error ==> $error->toShape()))->toEqual($expected_errors);
     }

--- a/tests/gen/AnotherObjectShape.hack
+++ b/tests/gen/AnotherObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<a055e6f0c0ac3eaf5e8478250fba8ebe>>
+ * @generated SignedSource<<2bc47b1fd4bb0ee1f51c3f3c22578e3b>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -26,7 +26,7 @@ final class AnotherObjectShape extends \Slack\GraphQL\Types\ObjectType {
       case 'abc':
         return new GraphQL\FieldDefinition(
           'abc',
-          Types\IntType::nonNullable()->nullableOutputListOf(),
+          Types\IntType::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent['abc'],
         );

--- a/tests/gen/Bot.hack
+++ b/tests/gen/Bot.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<ff2e2bcd02e234d2774911cb3059c0c1>>
+ * @generated SignedSource<<c869d010cabe358e6e0bdd6a37b68868>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -30,35 +30,35 @@ final class Bot extends \Slack\GraphQL\Types\ObjectType {
       case 'id':
         return new GraphQL\FieldDefinition(
           'id',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'is_active':
         return new GraphQL\FieldDefinition(
           'is_active',
-          Types\BooleanType::nullableOutput(),
+          Types\BooleanType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'primary_function':
         return new GraphQL\FieldDefinition(
           'primary_function',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getPrimaryFunction(),
         );
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
-          Team::nullableOutput(),
+          Team::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> await $parent->getTeam(),
         );

--- a/tests/gen/Concrete.hack
+++ b/tests/gen/Concrete.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e0e4917650700b456bdf6acbf02a66a7>>
+ * @generated SignedSource<<18929d891365b1f5f09d9b3f814b431c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -28,21 +28,21 @@ final class Concrete extends \Slack\GraphQL\Types\ObjectType {
       case 'bar':
         return new GraphQL\FieldDefinition(
           'bar',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->bar(),
         );
       case 'baz':
         return new GraphQL\FieldDefinition(
           'baz',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->baz(),
         );
       case 'foo':
         return new GraphQL\FieldDefinition(
           'foo',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->foo(),
         );

--- a/tests/gen/CreateTeamInput.hack
+++ b/tests/gen/CreateTeamInput.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<75a0b6a31b2d57480f9f9847bac621c5>>
+ * @generated SignedSource<<3bbf6e163c472729fb1c336941e86abc>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -24,7 +24,7 @@ final class CreateTeamInput extends \Slack\GraphQL\Types\InputObjectType {
     KeyedContainer<arraykey, mixed> $fields,
   ): this::THackType {
     $ret = shape();
-    $ret['name'] = Types\StringType::nonNullable()->coerceNamedValue('name', $fields);
+    $ret['name'] = Types\StringType::nonNullable($this->schema)->coerceNamedValue('name', $fields);
     return $ret;
   }
 
@@ -34,7 +34,7 @@ final class CreateTeamInput extends \Slack\GraphQL\Types\InputObjectType {
     dict<string, mixed> $vars,
   ): this::THackType {
     $ret = shape();
-    $ret['name'] = Types\StringType::nonNullable()->coerceNamedNode('name', $fields, $vars);
+    $ret['name'] = Types\StringType::nonNullable($this->schema)->coerceNamedNode('name', $fields, $vars);
     return $ret;
   }
 }

--- a/tests/gen/CreateUserInput.hack
+++ b/tests/gen/CreateUserInput.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d1da705de7b13fa3ac9c4c978215d91a>>
+ * @generated SignedSource<<2aa0a10b0a27de4963cb02798ebfb11f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -27,15 +27,15 @@ final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
     KeyedContainer<arraykey, mixed> $fields,
   ): this::THackType {
     $ret = shape();
-    $ret['name'] = Types\StringType::nonNullable()->coerceNamedValue('name', $fields);
+    $ret['name'] = Types\StringType::nonNullable($this->schema)->coerceNamedValue('name', $fields);
     if (C\contains_key($fields, 'is_active')) {
-      $ret['is_active'] = Types\BooleanType::nullableInput()->coerceNamedValue('is_active', $fields);
+      $ret['is_active'] = Types\BooleanType::nullableInput($this->schema)->coerceNamedValue('is_active', $fields);
     }
     if (C\contains_key($fields, 'team')) {
-      $ret['team'] = CreateTeamInput::nullableInput()->coerceNamedValue('team', $fields);
+      $ret['team'] = CreateTeamInput::nullableInput($this->schema)->coerceNamedValue('team', $fields);
     }
     if (C\contains_key($fields, 'favorite_color')) {
-      $ret['favorite_color'] = FavoriteColor::nullableInput()->coerceNamedValue('favorite_color', $fields);
+      $ret['favorite_color'] = FavoriteColor::nullableInput($this->schema)->coerceNamedValue('favorite_color', $fields);
     }
     return $ret;
   }
@@ -46,15 +46,15 @@ final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
     dict<string, mixed> $vars,
   ): this::THackType {
     $ret = shape();
-    $ret['name'] = Types\StringType::nonNullable()->coerceNamedNode('name', $fields, $vars);
+    $ret['name'] = Types\StringType::nonNullable($this->schema)->coerceNamedNode('name', $fields, $vars);
     if ($this->hasValue('is_active', $fields, $vars)) {
-      $ret['is_active'] = Types\BooleanType::nullableInput()->coerceNamedNode('is_active', $fields, $vars);
+      $ret['is_active'] = Types\BooleanType::nullableInput($this->schema)->coerceNamedNode('is_active', $fields, $vars);
     }
     if ($this->hasValue('team', $fields, $vars)) {
-      $ret['team'] = CreateTeamInput::nullableInput()->coerceNamedNode('team', $fields, $vars);
+      $ret['team'] = CreateTeamInput::nullableInput($this->schema)->coerceNamedNode('team', $fields, $vars);
     }
     if ($this->hasValue('favorite_color', $fields, $vars)) {
-      $ret['favorite_color'] = FavoriteColor::nullableInput()->coerceNamedNode('favorite_color', $fields, $vars);
+      $ret['favorite_color'] = FavoriteColor::nullableInput($this->schema)->coerceNamedNode('favorite_color', $fields, $vars);
     }
     return $ret;
   }

--- a/tests/gen/ErrorTestObj.hack
+++ b/tests/gen/ErrorTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<469d5bd682a221e51c109c1ae88bcbd4>>
+ * @generated SignedSource<<2bd9f28bf6c125e22dbf00bcb4b5ff6c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -37,84 +37,84 @@ final class ErrorTestObj extends \Slack\GraphQL\Types\ObjectType {
       case 'bad_int_list_n_of_n':
         return new GraphQL\FieldDefinition(
           'bad_int_list_n_of_n',
-          Types\IntType::nullableOutput()->nullableOutputListOf(),
+          Types\IntType::nullableOutput($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->bad_int_list_n_of_n(),
         );
       case 'bad_int_list_n_of_nn':
         return new GraphQL\FieldDefinition(
           'bad_int_list_n_of_nn',
-          Types\IntType::nonNullable()->nullableOutputListOf(),
+          Types\IntType::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->bad_int_list_n_of_nn(),
         );
       case 'bad_int_list_nn_of_nn':
         return new GraphQL\FieldDefinition(
           'bad_int_list_nn_of_nn',
-          Types\IntType::nonNullable()->nonNullableOutputListOf(),
+          Types\IntType::nonNullable($this->schema)->nonNullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->bad_int_list_nn_of_nn(),
         );
       case 'hidden_exception':
         return new GraphQL\FieldDefinition(
           'hidden_exception',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->hidden_exception(),
         );
       case 'nested':
         return new GraphQL\FieldDefinition(
           'nested',
-          ErrorTestObj::nullableOutput(),
+          ErrorTestObj::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->nested(),
         );
       case 'nested_list_n_of_n':
         return new GraphQL\FieldDefinition(
           'nested_list_n_of_n',
-          ErrorTestObj::nullableOutput()->nullableOutputListOf(),
+          ErrorTestObj::nullableOutput($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->nested_list_n_of_n(),
         );
       case 'nested_list_n_of_nn':
         return new GraphQL\FieldDefinition(
           'nested_list_n_of_nn',
-          ErrorTestObj::nonNullable()->nullableOutputListOf(),
+          ErrorTestObj::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->nested_list_n_of_nn(),
         );
       case 'nested_list_nn_of_nn':
         return new GraphQL\FieldDefinition(
           'nested_list_nn_of_nn',
-          ErrorTestObj::nonNullable()->nonNullableOutputListOf(),
+          ErrorTestObj::nonNullable($this->schema)->nonNullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->nested_list_nn_of_nn(),
         );
       case 'nested_nn':
         return new GraphQL\FieldDefinition(
           'nested_nn',
-          ErrorTestObj::nonNullable(),
+          ErrorTestObj::nonNullable($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->nested_nn(),
         );
       case 'no_error':
         return new GraphQL\FieldDefinition(
           'no_error',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->no_error(),
         );
       case 'non_nullable':
         return new GraphQL\FieldDefinition(
           'non_nullable',
-          Types\IntType::nonNullable(),
+          Types\IntType::nonNullable($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->non_nullable(),
         );
       case 'user_facing_error':
         return new GraphQL\FieldDefinition(
           'user_facing_error',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->user_facing_error(),
         );

--- a/tests/gen/Human.hack
+++ b/tests/gen/Human.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<af93826043cb57b9f05c3a1b4d3db12a>>
+ * @generated SignedSource<<5dbfa34d582b37fbfc7d828f9cd3753b>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -30,35 +30,35 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
       case 'favorite_color':
         return new GraphQL\FieldDefinition(
           'favorite_color',
-          FavoriteColor::nullableOutput(),
+          FavoriteColor::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getFavoriteColor(),
         );
       case 'id':
         return new GraphQL\FieldDefinition(
           'id',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'is_active':
         return new GraphQL\FieldDefinition(
           'is_active',
-          Types\BooleanType::nullableOutput(),
+          Types\BooleanType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
-          Team::nullableOutput(),
+          Team::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> await $parent->getTeam(),
         );

--- a/tests/gen/IIntrospectionInterfaceA.hack
+++ b/tests/gen/IIntrospectionInterfaceA.hack
@@ -1,0 +1,52 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<4101dfda10192bc1272aa8bb789e3337>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class IIntrospectionInterfaceA
+  extends \Slack\GraphQL\Types\InterfaceType {
+
+  const NAME = 'IIntrospectionInterfaceA';
+  const type THackType = \IIntrospectionInterfaceA;
+  const keyset<string> FIELD_NAMES = keyset[
+  ];
+  const keyset<string> POSSIBLE_TYPES = keyset[
+    'ImplementInterfaceB',
+    'ImplementInterfaceC',
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      default:
+        return null;
+    }
+  }
+
+  public async function resolveAsync(
+    this::THackType $value,
+    \Graphpinator\Parser\Field\IHasFieldSet $field,
+    GraphQL\Variables $vars,
+  ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
+    if ($value is \ImplementInterfaceB) {
+      return await ImplementInterfaceB::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
+    }
+    if ($value is \ImplementInterfaceC) {
+      return await ImplementInterfaceC::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
+    }
+    invariant_violation(
+      'Class %s has no associated GraphQL type or it is not a subtype of %s.',
+      \get_class($value),
+      static::NAME,
+    );
+  }
+}

--- a/tests/gen/IIntrospectionInterfaceB.hack
+++ b/tests/gen/IIntrospectionInterfaceB.hack
@@ -1,0 +1,52 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<7278e6c4fe3c36b748959101699073fc>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class IIntrospectionInterfaceB
+  extends \Slack\GraphQL\Types\InterfaceType {
+
+  const NAME = 'IIntrospectionInterfaceB';
+  const type THackType = \IIntrospectionInterfaceB;
+  const keyset<string> FIELD_NAMES = keyset[
+  ];
+  const keyset<string> POSSIBLE_TYPES = keyset[
+    'ImplementInterfaceB',
+    'ImplementInterfaceC',
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      default:
+        return null;
+    }
+  }
+
+  public async function resolveAsync(
+    this::THackType $value,
+    \Graphpinator\Parser\Field\IHasFieldSet $field,
+    GraphQL\Variables $vars,
+  ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
+    if ($value is \ImplementInterfaceB) {
+      return await ImplementInterfaceB::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
+    }
+    if ($value is \ImplementInterfaceC) {
+      return await ImplementInterfaceC::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
+    }
+    invariant_violation(
+      'Class %s has no associated GraphQL type or it is not a subtype of %s.',
+      \get_class($value),
+      static::NAME,
+    );
+  }
+}

--- a/tests/gen/IIntrospectionInterfaceC.hack
+++ b/tests/gen/IIntrospectionInterfaceC.hack
@@ -1,0 +1,48 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<2a14849c191bacf83baedda116a6bbd6>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class IIntrospectionInterfaceC
+  extends \Slack\GraphQL\Types\InterfaceType {
+
+  const NAME = 'IIntrospectionInterfaceC';
+  const type THackType = \IIntrospectionInterfaceC;
+  const keyset<string> FIELD_NAMES = keyset[
+  ];
+  const keyset<string> POSSIBLE_TYPES = keyset[
+    'ImplementInterfaceC',
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      default:
+        return null;
+    }
+  }
+
+  public async function resolveAsync(
+    this::THackType $value,
+    \Graphpinator\Parser\Field\IHasFieldSet $field,
+    GraphQL\Variables $vars,
+  ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
+    if ($value is \ImplementInterfaceC) {
+      return await ImplementInterfaceC::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
+    }
+    invariant_violation(
+      'Class %s has no associated GraphQL type or it is not a subtype of %s.',
+      \get_class($value),
+      static::NAME,
+    );
+  }
+}

--- a/tests/gen/ImplementInterfaceB.hack
+++ b/tests/gen/ImplementInterfaceB.hack
@@ -1,0 +1,29 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<9431ce789829f893678b8d5e524d889b>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class ImplementInterfaceB extends \Slack\GraphQL\Types\ObjectType {
+
+  const NAME = 'ImplementInterfaceB';
+  const type THackType = \ImplementInterfaceB;
+  const keyset<string> FIELD_NAMES = keyset[
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      default:
+        return null;
+    }
+  }
+}

--- a/tests/gen/ImplementInterfaceC.hack
+++ b/tests/gen/ImplementInterfaceC.hack
@@ -1,0 +1,29 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<32df98f268157f6628aec2a6db2762d4>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class ImplementInterfaceC extends \Slack\GraphQL\Types\ObjectType {
+
+  const NAME = 'ImplementInterfaceC';
+  const type THackType = \ImplementInterfaceC;
+  const keyset<string> FIELD_NAMES = keyset[
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      default:
+        return null;
+    }
+  }
+}

--- a/tests/gen/InterfaceA.hack
+++ b/tests/gen/InterfaceA.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<cca41607ccc70b964939cc1f90473059>>
+ * @generated SignedSource<<89716772ce6e846803b400abec704477>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -18,6 +18,9 @@ final class InterfaceA extends \Slack\GraphQL\Types\InterfaceType {
   const keyset<string> FIELD_NAMES = keyset[
     'foo',
   ];
+  const keyset<string> POSSIBLE_TYPES = keyset[
+    'Concrete',
+  ];
 
   public function getFieldDefinition(
     string $field_name,
@@ -26,7 +29,7 @@ final class InterfaceA extends \Slack\GraphQL\Types\InterfaceType {
       case 'foo':
         return new GraphQL\FieldDefinition(
           'foo',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->foo(),
         );
@@ -41,7 +44,7 @@ final class InterfaceA extends \Slack\GraphQL\Types\InterfaceType {
     GraphQL\Variables $vars,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \Concrete) {
-      return await Concrete::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Concrete::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/InterfaceB.hack
+++ b/tests/gen/InterfaceB.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<69078a12298d3db36a8d0a26e0f8ae6b>>
+ * @generated SignedSource<<d57d618ec5d07c63832e157d185c77b4>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,6 +19,9 @@ final class InterfaceB extends \Slack\GraphQL\Types\InterfaceType {
     'bar',
     'foo',
   ];
+  const keyset<string> POSSIBLE_TYPES = keyset[
+    'Concrete',
+  ];
 
   public function getFieldDefinition(
     string $field_name,
@@ -27,14 +30,14 @@ final class InterfaceB extends \Slack\GraphQL\Types\InterfaceType {
       case 'bar':
         return new GraphQL\FieldDefinition(
           'bar',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->bar(),
         );
       case 'foo':
         return new GraphQL\FieldDefinition(
           'foo',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->foo(),
         );
@@ -49,7 +52,7 @@ final class InterfaceB extends \Slack\GraphQL\Types\InterfaceType {
     GraphQL\Variables $vars,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \Concrete) {
-      return await Concrete::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Concrete::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/IntrospectionTestObject.hack
+++ b/tests/gen/IntrospectionTestObject.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<3265e2eae29f57617617f679a8411852>>
+ * @generated SignedSource<<dc4c9b60d65e41258df439f2ab99c767>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -32,49 +32,49 @@ final class IntrospectionTestObject extends \Slack\GraphQL\Types\ObjectType {
       case 'default_list_of_non_nullable_int':
         return new GraphQL\FieldDefinition(
           'default_list_of_non_nullable_int',
-          Types\IntType::nonNullable()->nullableOutputListOf(),
+          Types\IntType::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultListOfNonNullableInt(),
         );
       case 'default_list_of_nullable_int':
         return new GraphQL\FieldDefinition(
           'default_list_of_nullable_int',
-          Types\IntType::nullableOutput()->nullableOutputListOf(),
+          Types\IntType::nullableOutput($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultListOfNullableInt(),
         );
       case 'default_nullable_string':
         return new GraphQL\FieldDefinition(
           'default_nullable_string',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultNullableString(),
         );
       case 'non_null_int':
         return new GraphQL\FieldDefinition(
           'non_null_int',
-          Types\IntType::nonNullable(),
+          Types\IntType::nonNullable($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getNonNullInt(),
         );
       case 'non_null_list_of_non_null':
         return new GraphQL\FieldDefinition(
           'non_null_list_of_non_null',
-          Types\IntType::nonNullable()->nonNullableOutputListOf(),
+          Types\IntType::nonNullable($this->schema)->nonNullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getNonNullListOfNonNull(),
         );
       case 'non_null_string':
         return new GraphQL\FieldDefinition(
           'non_null_string',
-          Types\StringType::nonNullable(),
+          Types\StringType::nonNullable($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getNonNullString(),
         );
       case 'nullable_string':
         return new GraphQL\FieldDefinition(
           'nullable_string',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getNullableString(),
         );

--- a/tests/gen/Mutation.hack
+++ b/tests/gen/Mutation.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e6cc33b0f4eb7dbb597cd43d1a0e6fa3>>
+ * @generated SignedSource<<fb5cde473083f4b7b6bc96b1b5ee162a>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -27,29 +27,29 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
       case 'createUser':
         return new GraphQL\FieldDefinition(
           'createUser',
-          User::nullableOutput(),
+          User::nullableOutput($this->schema),
           dict[
             'input' => shape(
               'name' => 'input',
-              'type' => CreateUserInput::nonNullable(),
+              'type' => CreateUserInput::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> await \UserMutationAttributes::createUser(
-            CreateUserInput::nonNullable()->coerceNamedNode('input', $args, $vars),
+            CreateUserInput::nonNullable($this->schema)->coerceNamedNode('input', $args, $vars),
           ),
         );
       case 'pokeUser':
         return new GraphQL\FieldDefinition(
           'pokeUser',
-          User::nullableOutput(),
+          User::nullableOutput($this->schema),
           dict[
             'id' => shape(
               'name' => 'id',
-              'type' => Types\IntType::nonNullable(),
+              'type' => Types\IntType::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> await \UserMutationAttributes::pokeUser(
-            Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
+            Types\IntType::nonNullable($this->schema)->coerceNamedNode('id', $args, $vars),
           ),
         );
       default:

--- a/tests/gen/ObjectShape.hack
+++ b/tests/gen/ObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b65ebf52131aac2d95f68806d781cbf9>>
+ * @generated SignedSource<<163e680e26e614327ed50d4b0fc0536f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -28,21 +28,21 @@ final class ObjectShape extends \Slack\GraphQL\Types\ObjectType {
       case 'foo':
         return new GraphQL\FieldDefinition(
           'foo',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent['foo'],
         );
       case 'bar':
         return new GraphQL\FieldDefinition(
           'bar',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent['bar'] ?? null,
         );
       case 'baz':
         return new GraphQL\FieldDefinition(
           'baz',
-          AnotherObjectShape::nullableOutput(),
+          AnotherObjectShape::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent['baz'],
         );

--- a/tests/gen/OutputTypeTestObj.hack
+++ b/tests/gen/OutputTypeTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d76e4b7915817cb97e5f6e04d2bfd45f>>
+ * @generated SignedSource<<c68c886bbb579fbb906ba9c73b45d20c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -32,49 +32,49 @@ final class OutputTypeTestObj extends \Slack\GraphQL\Types\ObjectType {
       case 'awaitable':
         return new GraphQL\FieldDefinition(
           'awaitable',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> await $parent->awaitable(),
         );
       case 'awaitable_nullable':
         return new GraphQL\FieldDefinition(
           'awaitable_nullable',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> await $parent->awaitable_nullable(),
         );
       case 'awaitable_nullable_list':
         return new GraphQL\FieldDefinition(
           'awaitable_nullable_list',
-          Types\IntType::nonNullable()->nullableOutputListOf(),
+          Types\IntType::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> await $parent->awaitable_nullable_list(),
         );
       case 'list':
         return new GraphQL\FieldDefinition(
           'list',
-          Types\StringType::nonNullable()->nullableOutputListOf(),
+          Types\StringType::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->list(),
         );
       case 'nested_lists':
         return new GraphQL\FieldDefinition(
           'nested_lists',
-          Types\IntType::nullableOutput()->nonNullableOutputListOf()->nullableOutputListOf()->nullableOutputListOf(),
+          Types\IntType::nullableOutput($this->schema)->nonNullableOutputListOf()->nullableOutputListOf()->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->nested_lists(),
         );
       case 'nullable':
         return new GraphQL\FieldDefinition(
           'nullable',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->nullable(),
         );
       case 'scalar':
         return new GraphQL\FieldDefinition(
           'scalar',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->scalar(),
         );

--- a/tests/gen/Query.hack
+++ b/tests/gen/Query.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<84fbd9df814af1ce3381be10fc335999>>
+ * @generated SignedSource<<bffb321a4da8027e28c5535d4decc79d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -44,207 +44,207 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
       case '__schema':
         return new GraphQL\FieldDefinition(
           '__schema',
-          __Schema::nullableOutput(),
+          __Schema::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \Slack\GraphQL\Introspection\QueryRootFields::getSchema(),
         );
       case '__type':
         return new GraphQL\FieldDefinition(
           '__type',
-          __Type::nullableOutput(),
+          __Type::nullableOutput($this->schema),
           dict[
             'name' => shape(
               'name' => 'name',
-              'type' => Types\StringType::nonNullable(),
+              'type' => Types\StringType::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> \Slack\GraphQL\Introspection\QueryRootFields::getType(
-            Types\StringType::nonNullable()->coerceNamedNode('name', $args, $vars),
+            Types\StringType::nonNullable($this->schema)->coerceNamedNode('name', $args, $vars),
           ),
         );
       case 'arg_test':
         return new GraphQL\FieldDefinition(
           'arg_test',
-          Types\IntType::nullableOutput()->nullableOutputListOf(),
+          Types\IntType::nullableOutput($this->schema)->nullableOutputListOf(),
           dict[
             'required' => shape(
               'name' => 'required',
-              'type' => Types\IntType::nonNullable(),
+              'type' => Types\IntType::nonNullable($this->schema),
             ),
             'nullable' => shape(
               'name' => 'nullable',
-              'type' => Types\IntType::nullableInput(),
+              'type' => Types\IntType::nullableInput($this->schema),
             ),
             'optional' => shape(
               'name' => 'optional',
-              'type' => Types\IntType::nullableInput(),
+              'type' => Types\IntType::nullableInput($this->schema),
               'default_value' => 42,
             ),
           ],
           async ($parent, $args, $vars) ==> \ArgumentTestObj::argTest(
-            Types\IntType::nonNullable()->coerceNamedNode('required', $args, $vars),
-            Types\IntType::nullableInput()->coerceNamedNode('nullable', $args, $vars),
-            Types\IntType::nullableInput()->coerceOptionalNamedNode('optional', $args, $vars, 42),
+            Types\IntType::nonNullable($this->schema)->coerceNamedNode('required', $args, $vars),
+            Types\IntType::nullableInput($this->schema)->coerceNamedNode('nullable', $args, $vars),
+            Types\IntType::nullableInput($this->schema)->coerceOptionalNamedNode('optional', $args, $vars, 42),
           ),
         );
       case 'bot':
         return new GraphQL\FieldDefinition(
           'bot',
-          Bot::nullableOutput(),
+          Bot::nullableOutput($this->schema),
           dict[
             'id' => shape(
               'name' => 'id',
-              'type' => Types\IntType::nonNullable(),
+              'type' => Types\IntType::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getBot(
-            Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
+            Types\IntType::nonNullable($this->schema)->coerceNamedNode('id', $args, $vars),
           ),
         );
       case 'error_test':
         return new GraphQL\FieldDefinition(
           'error_test',
-          ErrorTestObj::nullableOutput(),
+          ErrorTestObj::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \ErrorTestObj::get(),
         );
       case 'error_test_nn':
         return new GraphQL\FieldDefinition(
           'error_test_nn',
-          ErrorTestObj::nonNullable(),
+          ErrorTestObj::nonNullable($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \ErrorTestObj::getNonNullable(),
         );
       case 'getConcrete':
         return new GraphQL\FieldDefinition(
           'getConcrete',
-          Concrete::nullableOutput(),
+          Concrete::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
         );
       case 'getInterfaceA':
         return new GraphQL\FieldDefinition(
           'getInterfaceA',
-          InterfaceA::nullableOutput(),
+          InterfaceA::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \Concrete::getInterfaceA(),
         );
       case 'getInterfaceB':
         return new GraphQL\FieldDefinition(
           'getInterfaceB',
-          InterfaceB::nullableOutput(),
+          InterfaceB::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \Concrete::getInterfaceB(),
         );
       case 'getObjectShape':
         return new GraphQL\FieldDefinition(
           'getObjectShape',
-          ObjectShape::nullableOutput(),
+          ObjectShape::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \ObjectTypeTestEntrypoint::getObjectShape(),
         );
       case 'human':
         return new GraphQL\FieldDefinition(
           'human',
-          Human::nullableOutput(),
+          Human::nullableOutput($this->schema),
           dict[
             'id' => shape(
               'name' => 'id',
-              'type' => Types\IntType::nonNullable(),
+              'type' => Types\IntType::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getHuman(
-            Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
+            Types\IntType::nonNullable($this->schema)->coerceNamedNode('id', $args, $vars),
           ),
         );
       case 'introspection_test':
         return new GraphQL\FieldDefinition(
           'introspection_test',
-          IntrospectionTestObject::nullableOutput(),
+          IntrospectionTestObject::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \IntrospectionTestObject::get(),
         );
       case 'list_arg_test':
         return new GraphQL\FieldDefinition(
           'list_arg_test',
-          Types\IntType::nonNullable()->nullableOutputListOf()->nullableOutputListOf()->nullableOutputListOf(),
+          Types\IntType::nonNullable($this->schema)->nullableOutputListOf()->nullableOutputListOf()->nullableOutputListOf(),
           dict[
             'arg' => shape(
               'name' => 'arg',
-              'type' => Types\IntType::nonNullable()->nullableInputListOf()->nonNullableInputListOf()->nullableInputListOf(),
+              'type' => Types\IntType::nonNullable($this->schema)->nullableInputListOf()->nonNullableInputListOf()->nullableInputListOf(),
             ),
           ],
           async ($parent, $args, $vars) ==> \ArgumentTestObj::listArgTest(
-            Types\IntType::nonNullable()->nullableInputListOf()->nonNullableInputListOf()->nullableInputListOf()->coerceNamedNode('arg', $args, $vars),
+            Types\IntType::nonNullable($this->schema)->nullableInputListOf()->nonNullableInputListOf()->nullableInputListOf()->coerceNamedNode('arg', $args, $vars),
           ),
         );
       case 'nested_list_sum':
         return new GraphQL\FieldDefinition(
           'nested_list_sum',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[
             'numbers' => shape(
               'name' => 'numbers',
-              'type' => Types\IntType::nonNullable()->nonNullableInputListOf()->nonNullableInputListOf(),
+              'type' => Types\IntType::nonNullable($this->schema)->nonNullableInputListOf()->nonNullableInputListOf(),
             ),
           ],
           async ($parent, $args, $vars) ==> \UserQueryAttributes::getNestedListSum(
-            Types\IntType::nonNullable()->nonNullableInputListOf()->nonNullableInputListOf()->coerceNamedNode('numbers', $args, $vars),
+            Types\IntType::nonNullable($this->schema)->nonNullableInputListOf()->nonNullableInputListOf()->coerceNamedNode('numbers', $args, $vars),
           ),
         );
       case 'optional_field_test':
         return new GraphQL\FieldDefinition(
           'optional_field_test',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[
             'input' => shape(
               'name' => 'input',
-              'type' => CreateUserInput::nonNullable(),
+              'type' => CreateUserInput::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> \UserQueryAttributes::optionalFieldTest(
-            CreateUserInput::nonNullable()->coerceNamedNode('input', $args, $vars),
+            CreateUserInput::nonNullable($this->schema)->coerceNamedNode('input', $args, $vars),
           ),
         );
       case 'output_type_test':
         return new GraphQL\FieldDefinition(
           'output_type_test',
-          OutputTypeTestObj::nullableOutput(),
+          OutputTypeTestObj::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> \OutputTypeTestObj::get(),
         );
       case 'takes_favorite_color':
         return new GraphQL\FieldDefinition(
           'takes_favorite_color',
-          Types\BooleanType::nullableOutput(),
+          Types\BooleanType::nullableOutput($this->schema),
           dict[
             'favorite_color' => shape(
               'name' => 'favorite_color',
-              'type' => FavoriteColor::nonNullable(),
+              'type' => FavoriteColor::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> \UserQueryAttributes::takesFavoriteColor(
-            FavoriteColor::nonNullable()->coerceNamedNode('favorite_color', $args, $vars),
+            FavoriteColor::nonNullable($this->schema)->coerceNamedNode('favorite_color', $args, $vars),
           ),
         );
       case 'user':
         return new GraphQL\FieldDefinition(
           'user',
-          User::nullableOutput(),
+          User::nullableOutput($this->schema),
           dict[
             'id' => shape(
               'name' => 'id',
-              'type' => Types\IntType::nonNullable(),
+              'type' => Types\IntType::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getUser(
-            Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
+            Types\IntType::nonNullable($this->schema)->coerceNamedNode('id', $args, $vars),
           ),
         );
       case 'viewer':
         return new GraphQL\FieldDefinition(
           'viewer',
-          User::nullableOutput(),
+          User::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getViewer(),
         );

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<01a084d48bc4b40d2a58229e523d72e9>>
+ * @generated SignedSource<<5e4fa0013e967e75f98a8d0f4bd11b6e>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -23,6 +23,11 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
     'ErrorTestObj' => ErrorTestObj::class,
     'FavoriteColor' => FavoriteColor::class,
     'Human' => Human::class,
+    'IIntrospectionInterfaceA' => IIntrospectionInterfaceA::class,
+    'IIntrospectionInterfaceB' => IIntrospectionInterfaceB::class,
+    'IIntrospectionInterfaceC' => IIntrospectionInterfaceC::class,
+    'ImplementInterfaceB' => ImplementInterfaceB::class,
+    'ImplementInterfaceC' => ImplementInterfaceC::class,
     'Int' => Types\IntType::class,
     'InterfaceA' => InterfaceA::class,
     'InterfaceB' => InterfaceB::class,
@@ -44,17 +49,17 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
   const classname<\Slack\GraphQL\Types\ObjectType> QUERY_TYPE = Query::class;
   const classname<\Slack\GraphQL\Types\ObjectType> MUTATION_TYPE = Mutation::class;
 
-  public static async function resolveQuery(
+  public async function resolveQuery(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\Variables $variables,
   ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
-    return await Query::nullableOutput()->resolveAsync(new GraphQL\Root(), $operation, $variables);
+    return await Query::nullableOutput($this)->resolveAsync(new GraphQL\Root(), $operation, $variables);
   }
 
-  public static async function resolveMutation(
+  public async function resolveMutation(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\Variables $variables,
   ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
-    return await Mutation::nullableOutput()->resolveAsync(new GraphQL\Root(), $operation, $variables);
+    return await Mutation::nullableOutput($this)->resolveAsync(new GraphQL\Root(), $operation, $variables);
   }
 }

--- a/tests/gen/Team.hack
+++ b/tests/gen/Team.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<2fcbc3a984824eb80a25483803a45585>>
+ * @generated SignedSource<<128bf27b615580223595a54af02c21ed>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,35 +29,35 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
       case 'description':
         return new GraphQL\FieldDefinition(
           'description',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[
             'short' => shape(
               'name' => 'short',
-              'type' => Types\BooleanType::nonNullable(),
+              'type' => Types\BooleanType::nonNullable($this->schema),
             ),
           ],
           async ($parent, $args, $vars) ==> $parent->getDescription(
-            Types\BooleanType::nonNullable()->coerceNamedNode('short', $args, $vars),
+            Types\BooleanType::nonNullable($this->schema)->coerceNamedNode('short', $args, $vars),
           ),
         );
       case 'id':
         return new GraphQL\FieldDefinition(
           'id',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'num_users':
         return new GraphQL\FieldDefinition(
           'num_users',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> await $parent->getNumUsers(),
         );

--- a/tests/gen/User.hack
+++ b/tests/gen/User.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<5c2c0756935563e010b733fb422f98fa>>
+ * @generated SignedSource<<fdced7776f71b1cb13cabf3cc160b118>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -21,6 +21,10 @@ final class User extends \Slack\GraphQL\Types\InterfaceType {
     'name',
     'team',
   ];
+  const keyset<string> POSSIBLE_TYPES = keyset[
+    'Bot',
+    'Human',
+  ];
 
   public function getFieldDefinition(
     string $field_name,
@@ -29,28 +33,28 @@ final class User extends \Slack\GraphQL\Types\InterfaceType {
       case 'id':
         return new GraphQL\FieldDefinition(
           'id',
-          Types\IntType::nullableOutput(),
+          Types\IntType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getId(),
         );
       case 'is_active':
         return new GraphQL\FieldDefinition(
           'is_active',
-          Types\BooleanType::nullableOutput(),
+          Types\BooleanType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->isActive(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
-          Team::nullableOutput(),
+          Team::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> await $parent->getTeam(),
         );
@@ -65,10 +69,10 @@ final class User extends \Slack\GraphQL\Types\InterfaceType {
     GraphQL\Variables $vars,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \Bot) {
-      return await Bot::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Bot::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
     }
     if ($value is \Human) {
-      return await Human::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Human::nonNullable($this->schema)->resolveAsync($value, $field, $vars);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/__EnumValue.hack
+++ b/tests/gen/__EnumValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<802276c16f369dd0037ca390373119c4>>
+ * @generated SignedSource<<b298217d385e7e0793958ba30839bae0>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,28 +29,28 @@ final class __EnumValue extends \Slack\GraphQL\Types\ObjectType {
       case 'deprecationReason':
         return new GraphQL\FieldDefinition(
           'deprecationReason',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getDeprecationReason(),
         );
       case 'description':
         return new GraphQL\FieldDefinition(
           'description',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getDescription(),
         );
       case 'isDeprecated':
         return new GraphQL\FieldDefinition(
           'isDeprecated',
-          Types\BooleanType::nullableOutput(),
+          Types\BooleanType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->isDeprecated(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );

--- a/tests/gen/__Field.hack
+++ b/tests/gen/__Field.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<037bfbdb594fcb15248df7a37a26c6f9>>
+ * @generated SignedSource<<fecf6463a57e6baf1033fa513f04d3db>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -27,14 +27,14 @@ final class __Field extends \Slack\GraphQL\Types\ObjectType {
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'type':
         return new GraphQL\FieldDefinition(
           'type',
-          __Type::nullableOutput(),
+          __Type::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getType(),
         );

--- a/tests/gen/__InputValue.hack
+++ b/tests/gen/__InputValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<a4fcf34b2f0d64dcaf8492c77090ab03>>
+ * @generated SignedSource<<94a6304776b008d796791c4b0798101c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,28 +29,28 @@ final class __InputValue extends \Slack\GraphQL\Types\ObjectType {
       case 'defaultValue':
         return new GraphQL\FieldDefinition(
           'defaultValue',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getDefaultValue(),
         );
       case 'description':
         return new GraphQL\FieldDefinition(
           'description',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getDescription(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
         );
       case 'type':
         return new GraphQL\FieldDefinition(
           'type',
-          __Type::nullableOutput(),
+          __Type::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getType(),
         );

--- a/tests/gen/__Schema.hack
+++ b/tests/gen/__Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d4671af9a4b12c09959f69533ec760a5>>
+ * @generated SignedSource<<245a7cbaf7ede78f86353bed3bb760bd>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -27,14 +27,14 @@ final class __Schema extends \Slack\GraphQL\Types\ObjectType {
       case 'mutationType':
         return new GraphQL\FieldDefinition(
           'mutationType',
-          __Type::nullableOutput(),
+          __Type::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionMutationType(),
         );
       case 'queryType':
         return new GraphQL\FieldDefinition(
           'queryType',
-          __Type::nullableOutput(),
+          __Type::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionQueryType(),
         );

--- a/tests/gen/__Type.hack
+++ b/tests/gen/__Type.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<4e1bfb13121b83b22d98d3bc73b26c8e>>
+ * @generated SignedSource<<77e01be885fdc912d3a02a656f650d66>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -34,87 +34,87 @@ final class __Type extends \Slack\GraphQL\Types\ObjectType {
       case 'description':
         return new GraphQL\FieldDefinition(
           'description',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionDescription(),
         );
       case 'enumValues':
         return new GraphQL\FieldDefinition(
           'enumValues',
-          __EnumValue::nonNullable()->nullableOutputListOf(),
+          __EnumValue::nonNullable($this->schema)->nullableOutputListOf(),
           dict[
             'include_deprecated' => shape(
               'name' => 'include_deprecated',
-              'type' => Types\BooleanType::nonNullable(),
+              'type' => Types\BooleanType::nonNullable($this->schema),
               'default_value' => false,
             ),
           ],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionEnumValues(
-            Types\BooleanType::nonNullable()->coerceOptionalNamedNode('include_deprecated', $args, $vars, false),
+            Types\BooleanType::nonNullable($this->schema)->coerceOptionalNamedNode('include_deprecated', $args, $vars, false),
           ),
         );
       case 'fields':
         return new GraphQL\FieldDefinition(
           'fields',
-          __Field::nonNullable()->nullableOutputListOf(),
+          __Field::nonNullable($this->schema)->nullableOutputListOf(),
           dict[
             'include_deprecated' => shape(
               'name' => 'include_deprecated',
-              'type' => Types\BooleanType::nonNullable(),
+              'type' => Types\BooleanType::nonNullable($this->schema),
               'default_value' => false,
             ),
           ],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionFields(
-            Types\BooleanType::nonNullable()->coerceOptionalNamedNode('include_deprecated', $args, $vars, false),
+            Types\BooleanType::nonNullable($this->schema)->coerceOptionalNamedNode('include_deprecated', $args, $vars, false),
           ),
         );
       case 'inputFields':
         return new GraphQL\FieldDefinition(
           'inputFields',
-          __InputValue::nonNullable()->nullableOutputListOf(),
+          __InputValue::nonNullable($this->schema)->nullableOutputListOf(),
           dict[
             'include_deprecated' => shape(
               'name' => 'include_deprecated',
-              'type' => Types\BooleanType::nonNullable(),
+              'type' => Types\BooleanType::nonNullable($this->schema),
               'default_value' => false,
             ),
           ],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionInputFields(
-            Types\BooleanType::nonNullable()->coerceOptionalNamedNode('include_deprecated', $args, $vars, false),
+            Types\BooleanType::nonNullable($this->schema)->coerceOptionalNamedNode('include_deprecated', $args, $vars, false),
           ),
         );
       case 'interfaces':
         return new GraphQL\FieldDefinition(
           'interfaces',
-          __Type::nonNullable()->nullableOutputListOf(),
+          __Type::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionInterfaces(),
         );
       case 'kind':
         return new GraphQL\FieldDefinition(
           'kind',
-          __TypeKind::nullableOutput(),
+          __TypeKind::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionKind(),
         );
       case 'name':
         return new GraphQL\FieldDefinition(
           'name',
-          Types\StringType::nullableOutput(),
+          Types\StringType::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionName(),
         );
       case 'ofType':
         return new GraphQL\FieldDefinition(
           'ofType',
-          __Type::nullableOutput(),
+          __Type::nullableOutput($this->schema),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionOfType(),
         );
       case 'possibleTypes':
         return new GraphQL\FieldDefinition(
           'possibleTypes',
-          __Type::nonNullable()->nullableOutputListOf(),
+          __Type::nonNullable($this->schema)->nullableOutputListOf(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getIntrospectionPossibleTypes(),
         );


### PR DESCRIPTION
We need access to the schema to be able to resolve name -> `__Type` for these two introspection fields:

```
  # OBJECT only
  interfaces: [__Type!]

  # INTERFACE and UNION only
  possibleTypes: [__Type!]
```

I liked this approach more than the previous approach where we injected schema if a `<<GraphQL\Field(...)>>` accepted `BaseSchema` as an argument. The schema is an implementation detail we shouldn't be exposing to any `GraphQL\Field` just because we happen to use those to power introspection. 

Schema doesn't technically store any state but we had a mix of static and instance methods so I just decided to remove the static methods since I didn't think they were giving us a lot.

I broke this up into two commits since most of this PR is just threading `$schema` through everywhere. The second commit implements `possibleTypes` which was trivial. 