### PR TITLE
implement field collection (aka defragmentation)

### DIFF
--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -12,7 +12,7 @@ abstract class BaseSchema implements Introspection\__Schema {
 
     abstract public static function resolveQuery(
         \Graphpinator\Parser\Operation\Operation $operation,
-        Variables $variables,
+        ExecutionContext $context,
     ): Awaitable<ValidFieldResult<?dict<string, mixed>>>;
 
     /**
@@ -21,7 +21,7 @@ abstract class BaseSchema implements Introspection\__Schema {
     */
     public static async function resolveMutation(
         \Graphpinator\Parser\Operation\Operation $operation,
-        Variables $variables,
+        ExecutionContext $context,
     ): Awaitable<ValidFieldResult<?dict<string, mixed>>> {
         return new ValidFieldResult(null);
     }

--- a/src/Codegen/Builders/InterfaceBuilder.hack
+++ b/src/Codegen/Builders/InterfaceBuilder.hack
@@ -35,14 +35,17 @@ final class InterfaceBuilder<TField as IFieldBuilder> extends CompositeBuilder<T
             ->setIsAsync()
             ->setReturnType('Awaitable<GraphQL\\FieldResult<dict<string, mixed>>>')
             ->addParameter('this::THackType $value')
-            ->addParameter('\\Graphpinator\\Parser\\Field\\IHasSelectionSet $field')
-            ->addParameter('GraphQL\\Variables $vars');
+            ->addParameterf('vec<\\%s> $parent_nodes', \Graphpinator\Parser\Field\IHasSelectionSet::class)
+            ->addParameterf('\\%s $context', \Slack\GraphQL\ExecutionContext::class);
 
         $hb = hb($cg);
         foreach ($this->hack_class_to_graphql_object as $hack_class => $graphql_type) {
             if (\is_subclass_of($hack_class, $this->hack_type)) {
                 $hb->startIfBlockf('$value is \\%s', $hack_class)
-                    ->addReturnf('await %s::nonNullable()->resolveAsync($value, $field, $vars)', $graphql_type)
+                    ->addReturnf(
+                        'await %s::nonNullable()->resolveAsync($value, $parent_nodes, $context)',
+                        $graphql_type,
+                    )
                     ->endIfBlock();
             }
         }

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -174,9 +174,9 @@ final class Generator {
             ->setIsAsync(true)
             ->setReturnType('Awaitable<GraphQL\\ValidFieldResult<?dict<string, mixed>>>')
             ->addParameterf('\%s $operation', \Graphpinator\Parser\Operation\Operation::class)
-            ->addParameterf('\%s $variables', \Slack\GraphQL\Variables::class);
+            ->addParameterf('\%s $context', \Slack\GraphQL\ExecutionContext::class);
 
-        $hb = hb($cg)->addReturnf('await %s->resolveAsync(new GraphQL\\Root(), $operation, $variables)', $root_type);
+        $hb = hb($cg)->addReturnf('await %s->resolveAsync(new GraphQL\\Root(), vec[$operation], $context)', $root_type);
 
         $resolve_method->setBody($hb->getCode());
 

--- a/src/ExecutionContext.hack
+++ b/src/ExecutionContext.hack
@@ -16,12 +16,7 @@ final class ExecutionContext {
         return $this->coercedVariableValues;
     }
 
-    public function getFragment(string $name): Fragment {
-        GraphQL\assert(
-            C\contains_key($this->fragmentDeclarations, $name),
-            'Unknown fragment "%s"',
-            $name,
-        );
+    public function getFragment(string $name): ?Fragment {
         return $this->fragmentDeclarations[$name];
     }
 }

--- a/src/ExecutionContext.hack
+++ b/src/ExecutionContext.hack
@@ -1,0 +1,27 @@
+namespace Slack\GraphQL;
+
+use namespace HH\Lib\C;
+use namespace Slack\GraphQL;
+
+use type Graphpinator\Parser\Fragment\Fragment;
+
+final class ExecutionContext {
+
+    public function __construct(
+        private dict<string, mixed> $coercedVariableValues,
+        private dict<string, Fragment> $fragmentDeclarations,
+    ) {}
+
+    public function getVariableValues(): dict<string, mixed> {
+        return $this->coercedVariableValues;
+    }
+
+    public function getFragment(string $name): Fragment {
+        GraphQL\assert(
+            C\contains_key($this->fragmentDeclarations, $name),
+            'Unknown fragment "%s"',
+            $name,
+        );
+        return $this->fragmentDeclarations[$name];
+    }
+}

--- a/src/FieldCollector.hack
+++ b/src/FieldCollector.hack
@@ -1,0 +1,75 @@
+namespace Slack\GraphQL;
+
+use namespace HH\Lib\C;
+use namespace Graphpinator\Parser;
+
+/**
+ * @see https://spec.graphql.org/draft/#sec-Field-Collection
+ */
+final class FieldCollector {
+
+    public static function collectFields(
+        Types\ObjectType $parent_type,
+        vec<Parser\Field\IHasSelectionSet> $parent_nodes,
+        ExecutionContext $context,
+    ): dict<string, vec<Parser\Field\Field>> {
+        $field_collector = new self($parent_type, $context);
+
+        foreach ($parent_nodes as $parent_node) {
+            $selection_set = $parent_node->getSelectionSet();
+            if ($selection_set is null) {
+                // This can only happen if the query wasn't validated.
+                throw (new UserFacingError('Missing selection set'))->setLocation($parent_node->getLocation());
+            }
+            $field_collector->processSelectionSet($selection_set);
+        }
+
+        return $field_collector->groupedFields;
+    }
+
+
+    private dict<string, vec<Parser\Field\Field>> $groupedFields = dict[];
+    private keyset<string> $visitedFragments = keyset[];
+
+    private function __construct(private Types\ObjectType $parentType, private ExecutionContext $context) {}
+
+    private function processSelectionSet(Parser\Field\SelectionSet $selection_set): void {
+        foreach ($selection_set->getItems() as $item) {
+            // TODO: @skip, @include
+
+            if ($item is Parser\Field\Field) {
+                $key = $item->getAlias() ?? $item->getName();
+                $this->groupedFields[$key] ??= vec[];
+                $this->groupedFields[$key][] = $item;
+
+            } else if ($item is Parser\FragmentSpread\NamedFragmentSpread) {
+                if (C\contains_key($this->visitedFragments, $item->getName())) {
+                    continue;
+                }
+                $this->visitedFragments[] = $item->getName();
+
+                $fragment = $this->context->getFragment($item->getName());
+                if (!$this->doesFragmentTypeApply($fragment->getTypeCond())) {
+                    continue;
+                }
+
+                $this->processSelectionSet($fragment->getSelectionSet());
+
+            } else {
+                $item as Parser\FragmentSpread\InlineFragmentSpread;
+
+                $fragment_type = $item->getTypeCond();
+                if ($fragment_type is nonnull && !$this->doesFragmentTypeApply($fragment_type)) {
+                    continue;
+                }
+
+                $this->processSelectionSet($item->getSelectionSet());
+            }
+        }
+    }
+
+    private function doesFragmentTypeApply(Parser\TypeRef\NamedTypeRef $fragment_type): bool {
+        $name = $fragment_type->getName();
+        return $name === $this->parentType->getName() || C\contains_key($this->parentType->getInterfaces(), $name);
+    }
+}

--- a/src/Graphpinator/Parser/Field/SelectionSet.hack
+++ b/src/Graphpinator/Parser/Field/SelectionSet.hack
@@ -18,8 +18,12 @@ final class SelectionSet extends \Graphpinator\Parser\Node {
 }
 
 interface IHasSelectionSet {
+    require extends \Graphpinator\Parser\Node;
     public function getSelectionSet(): ?SelectionSet;
 }
 
 <<__Sealed(Field::class, \Graphpinator\Parser\FragmentSpread\FragmentSpread::class)>>
-interface ISelectionSetItem {}
+interface ISelectionSetItem {
+    require extends \Graphpinator\Parser\Node;
+    public function getDirectives(): ?vec<\Graphpinator\Parser\Directive\Directive>;
+}

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -95,16 +95,19 @@ final class Resolver {
             $operation = C\onlyx($request->getOperations());
         }
 
-        $coerced_variables = $this->coerceVariables($operation->getVariables(), $raw_variables);
+        $context = new ExecutionContext(
+            $this->coerceVariables($operation->getVariables(), $raw_variables),
+            $request->getFragments(),
+        );
 
         $operation_type = $operation->getType();
         switch ($operation_type) {
             case 'query':
-                $result = await $schema::resolveQuery($operation, $coerced_variables);
+                $result = await $schema::resolveQuery($operation, $context);
                 break;
             case 'mutation':
                 invariant($schema::MUTATION_TYPE, 'mutation operation not supported for schema');
-                $result = await $schema::resolveMutation($operation, $coerced_variables);
+                $result = await $schema::resolveMutation($operation, $context);
                 break;
             default:
                 throw new \Error('Unsupported operation: '.$operation_type);

--- a/src/Types/InputOutput/LeafType.hack
+++ b/src/Types/InputOutput/LeafType.hack
@@ -16,8 +16,8 @@ abstract class LeafType extends NamedType {
     <<__Override>>
     final public async function resolveAsync(
         this::THackType $value,
-        \Graphpinator\Parser\Field\IHasSelectionSet $field,
-        GraphQL\Variables $vars,
+        vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+        GraphQL\ExecutionContext $context,
     ): Awaitable<GraphQL\FieldResult<this::TResolved>> {
         try {
             return new GraphQL\ValidFieldResult($this->serialize($value));

--- a/src/Types/Output/ListOutputType.hack
+++ b/src/Types/Output/ListOutputType.hack
@@ -20,8 +20,8 @@ final class ListOutputType<TInner, TResolved>
     <<__Override>>
     public async function resolveAsync(
         vec<TInner> $value,
-        \Graphpinator\Parser\Field\IHasSelectionSet $field,
-        GraphQL\Variables $vars,
+        vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+        GraphQL\ExecutionContext $context,
     ): Awaitable<GraphQL\FieldResult<vec<mixed>>> {
         $ret = vec[];
         $errors = vec[];
@@ -29,7 +29,7 @@ final class ListOutputType<TInner, TResolved>
 
         $results = await Vec\map_async(
             $value,
-            async $item ==> await $this->inner_type->resolveAsync($item, $field, $vars),
+            async $item ==> await $this->inner_type->resolveAsync($item, $parent_nodes, $context),
         );
 
         foreach ($results as $idx => $result) {

--- a/src/Types/Output/NullableOutputType.hack
+++ b/src/Types/Output/NullableOutputType.hack
@@ -23,13 +23,13 @@ final class NullableOutputType<TInner as nonnull, TResolved> extends BaseType {
     <<__Override>>
     public async function resolveAsync(
         ?TInner $value,
-        \Graphpinator\Parser\Field\IHasSelectionSet $field,
-        GraphQL\Variables $vars,
+        vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+        GraphQL\ExecutionContext $context,
     ): Awaitable<GraphQL\ValidFieldResult<?TResolved>> {
         if ($value is null) {
             return new GraphQL\ValidFieldResult(null);
         }
-        $result = await $this->inner_type->resolveAsync($value, $field, $vars);
+        $result = await $this->inner_type->resolveAsync($value, $parent_nodes, $context);
         return $result is GraphQL\ValidFieldResult<_>
             ? $result
             : new GraphQL\ValidFieldResult(null, $result->getErrors());

--- a/src/Types/Output/ObjectType.hack
+++ b/src/Types/Output/ObjectType.hack
@@ -24,8 +24,11 @@ abstract class ObjectType extends CompositeType {
 
         $results = await Dict\map_async(
             $grouped_child_fields,
-            async $grouped_child_field ==> {
-                $field_name = C\firstx($grouped_child_field)->getName();
+            async $grouped_field_nodes ==> {
+                // Validation guarantees all of the grouped field nodes have the same name (i.e. we don't have one alias
+                // pointing to 2 different fields in any selection set), so it doesn't matter which one we call
+                // getName() on.
+                $field_name = C\firstx($grouped_field_nodes)->getName();
                 if ($field_name === '__typename') {
                     // https://spec.graphql.org/draft/#sec-Type-Name-Introspection
                     return new GraphQL\ValidFieldResult(static::NAME);
@@ -34,7 +37,7 @@ abstract class ObjectType extends CompositeType {
                 if ($field_definition is null) {
                     throw new \Slack\GraphQL\UserFacingError('Unknown field: %s', $field_name);
                 }
-                return await $field_definition->resolveAsync($value, $grouped_child_field, $context);
+                return await $field_definition->resolveAsync($value, $grouped_field_nodes, $context);
             }
         );
 

--- a/src/Types/Output/OutputType.hack
+++ b/src/Types/Output/OutputType.hack
@@ -30,6 +30,9 @@ interface IOutputTypeFor<THackType, TResolved> extends IOutputType {
     /**
      * Convert a value returned by the field resolver into what should be put in the GraphQL response, possibly
      * recursively.
+     *
+     * Note that due to how FieldCollector works, there might be multiple parent nodes representing the same GraphQL
+     * response field (e.g. if the same field was included via 2 different fragments).
      */
     public function resolveAsync(
         THackType $value,

--- a/src/Types/Output/OutputType.hack
+++ b/src/Types/Output/OutputType.hack
@@ -33,8 +33,8 @@ interface IOutputTypeFor<THackType, TResolved> extends IOutputType {
      */
     public function resolveAsync(
         THackType $value,
-        \Graphpinator\Parser\Field\IHasSelectionSet $field,
-        GraphQL\Variables $vars,
+        vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+        GraphQL\ExecutionContext $context,
     ): Awaitable<GraphQL\FieldResult<TResolved>>;
 
     /**

--- a/tests/FragmentTest.hack
+++ b/tests/FragmentTest.hack
@@ -1,0 +1,61 @@
+use function Facebook\FBExpect\expect;
+
+use namespace Slack\GraphQL;
+
+final class FragmentTest extends PlaygroundTest {
+
+    <<__Override>>
+    public static function getTestCases(): this::TTestCases {
+        return dict[
+            'various interesting cases' => tuple(
+                '
+                    query {
+                        one: user(id: 1) { ...BotFrag, ...UserFrag, team { id } }
+                        two: bot(id: 2)  { ...BotFrag, ...UserFrag, team { id } }
+                    }
+
+                    fragment UserFrag on User {
+                        team { name }
+                        ... on Human {
+                            favorite_color
+                            team {
+                                aliased_field: name
+                                description(short: true)
+                            }
+                        }
+                        ...BotFrag
+                    }
+
+                    fragment BotFrag on Bot {
+                        primary_function
+                        team {
+                            aliased_field: description(short: false)
+                            num_users
+                        }
+                    }
+                ',
+                dict[],
+                dict[
+                    'one' => dict[
+                        'team' => dict[
+                            'name' => 'Test Team 1',
+                            'aliased_field' => 'Test Team 1',
+                            'description' => 'Short description',
+                            'id' => 1,
+                        ],
+                        'favorite_color' => 'BLUE',
+                    ],
+                    'two' => dict[
+                        'primary_function' => 'send spam',
+                        'team' => dict[
+                            'aliased_field' => 'Much longer description',
+                            'num_users' => 3,
+                            'name' => 'Test Team 1',
+                            'id' => 1,
+                        ],
+                    ],
+                ],
+            ),
+        ];
+    }
+}

--- a/tests/gen/IIntrospectionInterfaceA.hack
+++ b/tests/gen/IIntrospectionInterfaceA.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e0d3aee05dfb52a0843a819120e89c7d>>
+ * @generated SignedSource<<83c4ac9e30bde4ce823ffcb02f4260a4>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -35,17 +35,17 @@ final class IIntrospectionInterfaceA
 
   public async function resolveAsync(
     this::THackType $value,
-    \Graphpinator\Parser\Field\IHasSelectionSet $field,
-    GraphQL\Variables $vars,
+    vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \ImplementInterfaceA) {
-      return await ImplementInterfaceA::nonNullable()->resolveAsync($value, $field, $vars);
+      return await ImplementInterfaceA::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     if ($value is \ImplementInterfaceB) {
-      return await ImplementInterfaceB::nonNullable()->resolveAsync($value, $field, $vars);
+      return await ImplementInterfaceB::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     if ($value is \ImplementInterfaceC) {
-      return await ImplementInterfaceC::nonNullable()->resolveAsync($value, $field, $vars);
+      return await ImplementInterfaceC::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/IIntrospectionInterfaceB.hack
+++ b/tests/gen/IIntrospectionInterfaceB.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e1161cf0324bd84388e4b7b689f05d82>>
+ * @generated SignedSource<<12c9405d6c2b8a6c546a295fa510ad17>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -34,14 +34,14 @@ final class IIntrospectionInterfaceB
 
   public async function resolveAsync(
     this::THackType $value,
-    \Graphpinator\Parser\Field\IHasSelectionSet $field,
-    GraphQL\Variables $vars,
+    vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \ImplementInterfaceB) {
-      return await ImplementInterfaceB::nonNullable()->resolveAsync($value, $field, $vars);
+      return await ImplementInterfaceB::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     if ($value is \ImplementInterfaceC) {
-      return await ImplementInterfaceC::nonNullable()->resolveAsync($value, $field, $vars);
+      return await ImplementInterfaceC::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/IIntrospectionInterfaceC.hack
+++ b/tests/gen/IIntrospectionInterfaceC.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<051b3e6063c6d8bc356b8668c0eec5bc>>
+ * @generated SignedSource<<d06d895d4a7ab2979ee0cc35a2f46718>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -33,11 +33,11 @@ final class IIntrospectionInterfaceC
 
   public async function resolveAsync(
     this::THackType $value,
-    \Graphpinator\Parser\Field\IHasSelectionSet $field,
-    GraphQL\Variables $vars,
+    vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \ImplementInterfaceC) {
-      return await ImplementInterfaceC::nonNullable()->resolveAsync($value, $field, $vars);
+      return await ImplementInterfaceC::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/InterfaceA.hack
+++ b/tests/gen/InterfaceA.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<5a39a5b6bf54999d582a9bc1dd0cc7d3>>
+ * @generated SignedSource<<2692931475deaf2db40669c79479288f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -40,11 +40,11 @@ final class InterfaceA extends \Slack\GraphQL\Types\InterfaceType {
 
   public async function resolveAsync(
     this::THackType $value,
-    \Graphpinator\Parser\Field\IHasSelectionSet $field,
-    GraphQL\Variables $vars,
+    vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \Concrete) {
-      return await Concrete::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Concrete::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/InterfaceB.hack
+++ b/tests/gen/InterfaceB.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<508f1820cc9082f74c04c44d56f1bcd0>>
+ * @generated SignedSource<<e37a09e281723b18b775b5757b7f6675>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -48,11 +48,11 @@ final class InterfaceB extends \Slack\GraphQL\Types\InterfaceType {
 
   public async function resolveAsync(
     this::THackType $value,
-    \Graphpinator\Parser\Field\IHasSelectionSet $field,
-    GraphQL\Variables $vars,
+    vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \Concrete) {
-      return await Concrete::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Concrete::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<05fae459830946726df81669ba23886d>>
+ * @generated SignedSource<<9e2664d1abcbb202090d5856437227d8>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -54,15 +54,15 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
 
   public static async function resolveQuery(
     \Graphpinator\Parser\Operation\Operation $operation,
-    \Slack\GraphQL\Variables $variables,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
-    return await Query::nullableOutput()->resolveAsync(new GraphQL\Root(), $operation, $variables);
+    return await Query::nullableOutput()->resolveAsync(new GraphQL\Root(), vec[$operation], $context);
   }
 
   public static async function resolveMutation(
     \Graphpinator\Parser\Operation\Operation $operation,
-    \Slack\GraphQL\Variables $variables,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
-    return await Mutation::nullableOutput()->resolveAsync(new GraphQL\Root(), $operation, $variables);
+    return await Mutation::nullableOutput()->resolveAsync(new GraphQL\Root(), vec[$operation], $context);
   }
 }

--- a/tests/gen/User.hack
+++ b/tests/gen/User.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<5605d5af6b4e966ef171be1dca8bbc94>>
+ * @generated SignedSource<<481a5396998f1863b06a6992d837fe3b>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -65,14 +65,14 @@ final class User extends \Slack\GraphQL\Types\InterfaceType {
 
   public async function resolveAsync(
     this::THackType $value,
-    \Graphpinator\Parser\Field\IHasSelectionSet $field,
-    GraphQL\Variables $vars,
+    vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+    \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
     if ($value is \Bot) {
-      return await Bot::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Bot::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     if ($value is \Human) {
-      return await Human::nonNullable()->resolveAsync($value, $field, $vars);
+      return await Human::nonNullable()->resolveAsync($value, $parent_nodes, $context);
     }
     invariant_violation(
       'Class %s has no associated GraphQL type or it is not a subtype of %s.',


### PR DESCRIPTION
This makes it possible to execute queries with fragments, including all the fun cases around nested fragments and nested overlapping selection sets (see new test case).

One missing part is correctly codegenning the `INTERACES` const on object types (similarly to `POSSIBLE_TYPES` on interfaces) -- I assumed @mwildehahn is probably working on that already so for now I just hardcoded the value that makes the test pass :)