### PR TITLE
Support introspecting interfaces an object implements

### DIFF
--- a/src/Codegen/Builders/ObjectBuilder.hack
+++ b/src/Codegen/Builders/ObjectBuilder.hack
@@ -1,7 +1,13 @@
 namespace Slack\GraphQL\Codegen;
 
 use namespace HH\Lib\{Vec, Str};
-use type Facebook\HackCodegen\{CodegenClass, HackCodegenFactory, CodegenClassConstant, HackBuilderValues};
+use type Facebook\HackCodegen\{
+    CodegenClass,
+    HackCodegenFactory,
+    CodegenClassConstant,
+    HackBuilderValues,
+    HackBuilderKeys,
+};
 
 final class ObjectBuilder<TField as IFieldBuilder> extends CompositeBuilder<TField> {
     const classname<\Slack\GraphQL\Types\ObjectType> SUPERCLASS = \Slack\GraphQL\Types\ObjectType::class;
@@ -11,7 +17,7 @@ final class ObjectBuilder<TField as IFieldBuilder> extends CompositeBuilder<TFie
         \Slack\GraphQL\__Private\CompositeType $type_info,
         string $hack_type,
         vec<TField> $fields,
-        private keyset<string> $interfaces,
+        private dict<string, string> $hack_class_to_graphql_interface,
     ) {
         parent::__construct($type_info, $hack_type, $fields);
     }
@@ -25,7 +31,7 @@ final class ObjectBuilder<TField as IFieldBuilder> extends CompositeBuilder<TFie
     public static function fromTypeAlias<T>(
         \Slack\GraphQL\ObjectType $type_info,
         \ReflectionTypeAlias $type_alias,
-        keyset<string> $interfaces,
+        dict<string, string> $hack_class_to_graphql_interface,
     ): ObjectBuilder<ShapeFieldBuilder<T>> {
         $ts = $type_alias->getResolvedTypeStructure();
         invariant(
@@ -37,20 +43,20 @@ final class ObjectBuilder<TField as IFieldBuilder> extends CompositeBuilder<TFie
             $type_info,
             $type_alias->getName(),
             Vec\map_with_key($ts['fields'], ($name, $ts) ==> new ShapeFieldBuilder($name, $ts)),
-            $interfaces,
+            $hack_class_to_graphql_interface,
         );
     }
 
     private function generateInterfacesConstant(HackCodegenFactory $cg): CodegenClassConstant {
-        $interfaces = keyset[];
-        foreach ($this->interfaces as $interface) {
-            if (\is_subclass_of($this->hack_type, $interface)) {
-                $interfaces[] = Str\format('%s::class', $interface);
+        $interfaces = dict[];
+        foreach ($this->hack_class_to_graphql_interface as $hack_class => $graphql_type) {
+            if (\is_subclass_of($this->hack_type, $hack_class)) {
+                $interfaces[$graphql_type] = Str\format('%s::class', $hack_class);
             }
         }
 
         return $cg->codegenClassConstant('INTERFACES')
-            ->setType('keyset<classname<Types\InterfaceType>>')
-            ->setValue($interfaces, HackBuilderValues::keyset(HackBuilderValues::literal()));
+            ->setType('dict<string, classname<Types\InterfaceType>>')
+            ->setValue($interfaces, HackBuilderValues::dict(HackBuilderKeys::export(), HackBuilderValues::literal()));
     }
 }

--- a/src/Codegen/Builders/ObjectBuilder.hack
+++ b/src/Codegen/Builders/ObjectBuilder.hack
@@ -1,13 +1,31 @@
 namespace Slack\GraphQL\Codegen;
 
-use namespace HH\Lib\Vec;
+use namespace HH\Lib\{Vec, Str};
+use type Facebook\HackCodegen\{CodegenClass, HackCodegenFactory, CodegenClassConstant, HackBuilderValues};
 
 final class ObjectBuilder<TField as IFieldBuilder> extends CompositeBuilder<TField> {
     const classname<\Slack\GraphQL\Types\ObjectType> SUPERCLASS = \Slack\GraphQL\Types\ObjectType::class;
 
+    <<__Override>>
+    public function __construct(
+        \Slack\GraphQL\__Private\CompositeType $type_info,
+        string $hack_type,
+        vec<TField> $fields,
+        private keyset<string> $interfaces,
+    ) {
+        parent::__construct($type_info, $hack_type, $fields);
+    }
+
+    <<__Override>>
+    public function build(HackCodegenFactory $cg): CodegenClass {
+        return parent::build($cg)
+            ->addConstant($this->generateInterfacesConstant($cg));
+    }
+
     public static function fromTypeAlias<T>(
         \Slack\GraphQL\ObjectType $type_info,
         \ReflectionTypeAlias $type_alias,
+        keyset<string> $interfaces,
     ): ObjectBuilder<ShapeFieldBuilder<T>> {
         $ts = $type_alias->getResolvedTypeStructure();
         invariant(
@@ -19,6 +37,20 @@ final class ObjectBuilder<TField as IFieldBuilder> extends CompositeBuilder<TFie
             $type_info,
             $type_alias->getName(),
             Vec\map_with_key($ts['fields'], ($name, $ts) ==> new ShapeFieldBuilder($name, $ts)),
+            $interfaces,
         );
+    }
+
+    private function generateInterfacesConstant(HackCodegenFactory $cg): CodegenClassConstant {
+        $interfaces = keyset[];
+        foreach ($this->interfaces as $interface) {
+            if (\is_subclass_of($this->hack_type, $interface)) {
+                $interfaces[] = Str\format('%s::class', $interface);
+            }
+        }
+
+        return $cg->codegenClassConstant('INTERFACES')
+            ->setType('keyset<classname<Types\InterfaceType>>')
+            ->setValue($interfaces, HackBuilderValues::keyset(HackBuilderValues::literal()));
     }
 }

--- a/src/Codegen/Builders/ObjectBuilder.hack
+++ b/src/Codegen/Builders/ObjectBuilder.hack
@@ -51,7 +51,7 @@ final class ObjectBuilder<TField as IFieldBuilder> extends CompositeBuilder<TFie
         $interfaces = dict[];
         foreach ($this->hack_class_to_graphql_interface as $hack_class => $graphql_type) {
             if (\is_subclass_of($this->hack_type, $hack_class)) {
-                $interfaces[$graphql_type] = Str\format('%s::class', $hack_class);
+                $interfaces[$graphql_type] = Str\format('%s::class', $graphql_type);
             }
         }
 

--- a/src/Introspection/__Type.hack
+++ b/src/Introspection/__Type.hack
@@ -15,8 +15,7 @@ interface __Type {
     <<GraphQL\Field('name', 'Name of the type')>>
     public function getIntrospectionName(): ?string;
 
-    // TODO:
-
+    // TODO: description
     <<GraphQL\Field('description', 'Description of the type')>>
     public function getIntrospectionDescription(): ?string;
 
@@ -29,9 +28,11 @@ interface __Type {
     <<GraphQL\Field('possibleTypes', 'Possible types that implement this interface, only applies to INTERFACE')>>
     public function getIntrospectionPossibleTypes(): ?vec<__Type>;
 
+    // TODO: enumValues
     <<GraphQL\Field('enumValues', 'Enum values, only applies to ENUM')>>
     public function getIntrospectionEnumValues(bool $include_deprecated = false): ?vec<__EnumValue>;
 
+    // TODO: inputFields
     <<GraphQL\Field('inputFields', 'Input fields, only applies to INPUT_OBJECT')>>
     public function getIntrospectionInputFields(bool $include_deprecated = false): ?vec<__InputValue>;
 

--- a/src/Types/NonNullableType.hack
+++ b/src/Types/NonNullableType.hack
@@ -8,7 +8,7 @@ interface INonNullableType {
     public function getName(): ?string;
     public function getDescription(): ?string;
     public function getFields(bool $include_deprecated = false): ?vec<Introspection\__Field>;
-    public function getInterfaces(): ?vec<Introspection\__Type>;
+    public function getInterfaces(): ?vec<InterfaceType>;
     public function getPossibleTypes(): ?vec<ObjectType>;
     public function getEnumValues(bool $include_deprecated = false): ?vec<Introspection\__EnumValue>;
     public function getInputFields(bool $include_deprecated = false): ?vec<Introspection\__InputValue>;
@@ -87,7 +87,7 @@ trait TNonNullableType implements INonNullableType {
         return null;
     }
 
-    public function getInterfaces(): ?vec<Introspection\__Type> {
+    public function getInterfaces(): ?vec<InterfaceType> {
         return null;
     }
 

--- a/src/Types/NonNullableType.hack
+++ b/src/Types/NonNullableType.hack
@@ -8,8 +8,8 @@ interface INonNullableType {
     public function getName(): ?string;
     public function getDescription(): ?string;
     public function getFields(bool $include_deprecated = false): ?vec<Introspection\__Field>;
-    public function getInterfaces(): ?vec<InterfaceType>;
-    public function getPossibleTypes(): ?vec<ObjectType>;
+    public function getInterfaces(): ?dict<string, classname<InterfaceType>>;
+    public function getPossibleTypes(): ?vec<classname<ObjectType>>;
     public function getEnumValues(bool $include_deprecated = false): ?vec<Introspection\__EnumValue>;
     public function getInputFields(bool $include_deprecated = false): ?vec<Introspection\__InputValue>;
     public function getOfType(): ?Introspection\__Type;
@@ -87,11 +87,11 @@ trait TNonNullableType implements INonNullableType {
         return null;
     }
 
-    public function getInterfaces(): ?vec<InterfaceType> {
+    public function getInterfaces(): ?dict<string, classname<InterfaceType>> {
         return null;
     }
 
-    public function getPossibleTypes(): ?vec<ObjectType> {
+    public function getPossibleTypes(): ?vec<classname<ObjectType>> {
         return null;
     }
 

--- a/src/Types/NullableType.hack
+++ b/src/Types/NullableType.hack
@@ -37,15 +37,13 @@ trait TNullableType implements INullableType {
     <<__Override>>
     final public function getIntrospectionInterfaces(): ?vec<Introspection\__Type> {
         $interfaces = $this->getInnerType()->getInterfaces();
-        return $interfaces is nonnull
-            ? Vec\map($interfaces, $interface ==> $interface->nullableForIntrospection())
-            : null;
+        return $interfaces is nonnull ? Vec\map($interfaces, $interface ==> $interface::nullableOutput()) : null;
     }
 
     <<__Override>>
     final public function getIntrospectionPossibleTypes(): ?vec<Introspection\__Type> {
         $types = $this->getInnerType()->getPossibleTypes();
-        return $types is nonnull ? Vec\map($types, $type ==> $type->nullableForIntrospection()) : null;
+        return $types is nonnull ? Vec\map($types, $type ==> $type::nullableOutput()) : null;
     }
 
     <<__Override>>

--- a/src/Types/NullableType.hack
+++ b/src/Types/NullableType.hack
@@ -36,7 +36,10 @@ trait TNullableType implements INullableType {
 
     <<__Override>>
     final public function getIntrospectionInterfaces(): ?vec<Introspection\__Type> {
-        return $this->getInnerType()->getInterfaces();
+        $interfaces = $this->getInnerType()->getInterfaces();
+        return $interfaces is nonnull
+            ? Vec\map($interfaces, $interface ==> $interface->nullableForIntrospection())
+            : null;
     }
 
     <<__Override>>

--- a/src/Types/Output/InterfaceType.hack
+++ b/src/Types/Output/InterfaceType.hack
@@ -12,7 +12,7 @@ abstract class InterfaceType extends CompositeType {
     }
 
     <<__Override>>
-    final public function getPossibleTypes(): vec<ObjectType> {
-        return Vec\map(static::POSSIBLE_TYPES, $type ==> $type::nonNullable());
+    final public function getPossibleTypes(): vec<classname<ObjectType>> {
+        return vec(static::POSSIBLE_TYPES);
     }
 }

--- a/src/Types/Output/ObjectType.hack
+++ b/src/Types/Output/ObjectType.hack
@@ -4,7 +4,7 @@ use namespace HH\Lib\{Dict, Vec};
 use namespace Slack\GraphQL;
 
 abstract class ObjectType extends CompositeType {
-    abstract const keyset<classname<InterfaceType>> INTERFACES;
+    abstract const dict<string, classname<InterfaceType>> INTERFACES;
 
     abstract public function getFieldDefinition(
         string $field_name,
@@ -64,7 +64,7 @@ abstract class ObjectType extends CompositeType {
     }
 
     <<__Override>>
-    final public function getInterfaces(): vec<InterfaceType> {
-        return Vec\map(static::INTERFACES, $interface ==> $interface::nonNullable());
+    final public function getInterfaces(): dict<string, classname<InterfaceType>> {
+        return static::INTERFACES;
     }
 }

--- a/src/Types/Output/ObjectType.hack
+++ b/src/Types/Output/ObjectType.hack
@@ -4,9 +4,10 @@ use namespace HH\Lib\{Dict, Vec};
 use namespace Slack\GraphQL;
 
 abstract class ObjectType extends CompositeType {
+    abstract const keyset<classname<InterfaceType>> INTERFACES;
 
     abstract public function getFieldDefinition(
-        string $field_name
+        string $field_name,
     ): ?GraphQL\IResolvableFieldDefinition<this::THackType>;
 
     <<__Override>>
@@ -40,7 +41,7 @@ abstract class ObjectType extends CompositeType {
                     throw new \Slack\GraphQL\UserFacingError('Unknown field: %s', $child_field->getName());
                 }
                 return await $field_definition->resolveAsync($value, $child_field, $vars);
-            }
+            },
         );
 
         foreach ($results as $key => $result) {
@@ -60,5 +61,10 @@ abstract class ObjectType extends CompositeType {
     <<__Override>>
     final public function getKind(): GraphQL\Introspection\__TypeKind {
         return GraphQL\Introspection\__TypeKind::OBJECT;
+    }
+
+    <<__Override>>
+    final public function getInterfaces(): vec<InterfaceType> {
+        return Vec\map(static::INTERFACES, $interface ==> $interface::nonNullable());
     }
 }

--- a/src/playground/InterfaceTestObjects.hack
+++ b/src/playground/InterfaceTestObjects.hack
@@ -9,7 +9,7 @@ interface InterfaceA {
 
 <<GraphQL\InterfaceType('InterfaceB', 'InterfaceB')>>
 interface InterfaceB extends InterfaceA {
-    
+
     <<GraphQL\Field('bar', 'bar')>>
     public function bar(): string;
 }

--- a/src/playground/IntrospectionTestObjects.hack
+++ b/src/playground/IntrospectionTestObjects.hack
@@ -7,7 +7,7 @@ interface IIntrospectionInterfaceA {}
 interface IIntrospectionInterfaceB extends IIntrospectionInterfaceA {}
 
 <<GraphQL\InterfaceType('IIntrospectionInterfaceC', 'IIntrospectionInterfaceC')>>
-interface IIntrospectionInterfaceC extends IIntrospectionInterfaceB {}
+interface IIntrospectionInterfaceCDifferentClassNameThanGraphQLType extends IIntrospectionInterfaceB {}
 
 <<GraphQL\ObjectType('ImplementInterfaceA', 'ImplementInterfaceA')>>
 final class ImplementInterfaceA implements IIntrospectionInterfaceA {}
@@ -16,7 +16,8 @@ final class ImplementInterfaceA implements IIntrospectionInterfaceA {}
 final class ImplementInterfaceB implements IIntrospectionInterfaceB {}
 
 <<GraphQL\ObjectType('ImplementInterfaceC', 'ImplementInterfaceC')>>
-final class ImplementInterfaceC implements IIntrospectionInterfaceB, IIntrospectionInterfaceC {}
+final class ImplementInterfaceC
+    implements IIntrospectionInterfaceB, IIntrospectionInterfaceCDifferentClassNameThanGraphQLType {}
 
 <<GraphQL\ObjectType('IntrospectionTestObject', 'Test object for introspection')>>
 final class IntrospectionTestObject {

--- a/src/playground/IntrospectionTestObjects.hack
+++ b/src/playground/IntrospectionTestObjects.hack
@@ -9,6 +9,9 @@ interface IIntrospectionInterfaceB extends IIntrospectionInterfaceA {}
 <<GraphQL\InterfaceType('IIntrospectionInterfaceC', 'IIntrospectionInterfaceC')>>
 interface IIntrospectionInterfaceC extends IIntrospectionInterfaceB {}
 
+<<GraphQL\ObjectType('ImplementInterfaceA', 'ImplementInterfaceA')>>
+final class ImplementInterfaceA implements IIntrospectionInterfaceA {}
+
 <<GraphQL\ObjectType('ImplementInterfaceB', 'ImplementInterfaceB')>>
 final class ImplementInterfaceB implements IIntrospectionInterfaceB {}
 

--- a/tests/IntrospectionTest.hack
+++ b/tests/IntrospectionTest.hack
@@ -21,6 +21,9 @@ final class IntrospectionTest extends PlaygroundTest {
                     '__type' => dict[
                         'possibleTypes' => vec[
                             dict[
+                                'name' => 'ImplementInterfaceA',
+                            ],
+                            dict[
                                 'name' => 'ImplementInterfaceB',
                             ],
                             dict[
@@ -46,6 +49,65 @@ final class IntrospectionTest extends PlaygroundTest {
                                 'name' => 'ImplementInterfaceC',
                             ],
                         ],
+                    ],
+                ],
+            ),
+            'validate object introspection with multiple interfaces' => tuple(
+                '{
+                    __type(name: "ImplementInterfaceC") {
+                        interfaces {
+                            name
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    '__type' => dict[
+                        'interfaces' => vec[
+                            dict[
+                                'name' => 'IIntrospectionInterfaceA',
+                            ],
+                            dict[
+                                'name' => 'IIntrospectionInterfaceB',
+                            ],
+                            dict[
+                                'name' => 'IIntrospectionInterfaceC',
+                            ],
+                        ],
+                    ],
+                ],
+            ),
+            'validate object introspection with a single interface' => tuple(
+                '{
+                    __type(name: "ImplementInterfaceA") {
+                        interfaces {
+                            name
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    '__type' => dict[
+                        'interfaces' => vec[
+                            dict[
+                                'name' => 'IIntrospectionInterfaceA',
+                            ],
+                        ],
+                    ],
+                ],
+            ),
+            'validate object introspection with no interfaces' => tuple(
+                '{
+                    __type(name: "IntrospectionTestObject") {
+                        interfaces {
+                            name
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    '__type' => dict[
+                        'interfaces' => vec[],
                     ],
                 ],
             ),

--- a/tests/gen/AnotherObjectShape.hack
+++ b/tests/gen/AnotherObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<a055e6f0c0ac3eaf5e8478250fba8ebe>>
+ * @generated SignedSource<<64d02380948356a0694e6f027256e9f8>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -17,6 +17,8 @@ final class AnotherObjectShape extends \Slack\GraphQL\Types\ObjectType {
   const type THackType = \AnotherObjectShape;
   const keyset<string> FIELD_NAMES = keyset[
     'abc',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/AnotherObjectShape.hack
+++ b/tests/gen/AnotherObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<64d02380948356a0694e6f027256e9f8>>
+ * @generated SignedSource<<1df6595e51f53c069509e4a7216ba04f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -18,7 +18,7 @@ final class AnotherObjectShape extends \Slack\GraphQL\Types\ObjectType {
   const keyset<string> FIELD_NAMES = keyset[
     'abc',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Bot.hack
+++ b/tests/gen/Bot.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<ff2e2bcd02e234d2774911cb3059c0c1>>
+ * @generated SignedSource<<a411f03e623a3844be2730baabf1dff2>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -21,6 +21,9 @@ final class Bot extends \Slack\GraphQL\Types\ObjectType {
     'name',
     'primary_function',
     'team',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+    User::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Bot.hack
+++ b/tests/gen/Bot.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<a411f03e623a3844be2730baabf1dff2>>
+ * @generated SignedSource<<803c718476e0461c3e9d70a1db853f34>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -22,8 +22,8 @@ final class Bot extends \Slack\GraphQL\Types\ObjectType {
     'primary_function',
     'team',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
-    User::class,
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+    'User' => User::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Concrete.hack
+++ b/tests/gen/Concrete.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<74d93b9605c2bc46dc81efd52dbc4303>>
+ * @generated SignedSource<<5e33a7e29516c49900df494dac33f7f5>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -20,9 +20,9 @@ final class Concrete extends \Slack\GraphQL\Types\ObjectType {
     'baz',
     'foo',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
-    InterfaceA::class,
-    InterfaceB::class,
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+    'InterfaceA' => InterfaceA::class,
+    'InterfaceB' => InterfaceB::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Concrete.hack
+++ b/tests/gen/Concrete.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e0e4917650700b456bdf6acbf02a66a7>>
+ * @generated SignedSource<<74d93b9605c2bc46dc81efd52dbc4303>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,6 +19,10 @@ final class Concrete extends \Slack\GraphQL\Types\ObjectType {
     'bar',
     'baz',
     'foo',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+    InterfaceA::class,
+    InterfaceB::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ErrorTestObj.hack
+++ b/tests/gen/ErrorTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<469d5bd682a221e51c109c1ae88bcbd4>>
+ * @generated SignedSource<<04b2a2e5aee333aca813056e45eb5253>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -28,6 +28,8 @@ final class ErrorTestObj extends \Slack\GraphQL\Types\ObjectType {
     'no_error',
     'non_nullable',
     'user_facing_error',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ErrorTestObj.hack
+++ b/tests/gen/ErrorTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<04b2a2e5aee333aca813056e45eb5253>>
+ * @generated SignedSource<<4938ded1db5fdd04f9875088d7f4978d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,7 +29,7 @@ final class ErrorTestObj extends \Slack\GraphQL\Types\ObjectType {
     'non_nullable',
     'user_facing_error',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Human.hack
+++ b/tests/gen/Human.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<eedc43d8053645f89ff76e3086d1940b>>
+ * @generated SignedSource<<44300e4bf463295c174cb50f838e36e6>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -22,8 +22,8 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
     'name',
     'team',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
-    User::class,
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+    'User' => User::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Human.hack
+++ b/tests/gen/Human.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<af93826043cb57b9f05c3a1b4d3db12a>>
+ * @generated SignedSource<<eedc43d8053645f89ff76e3086d1940b>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -21,6 +21,9 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
     'is_active',
     'name',
     'team',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+    User::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/IIntrospectionInterfaceA.hack
+++ b/tests/gen/IIntrospectionInterfaceA.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<6e3b6f20750a5f7fc2e320bcdac3b92c>>
+ * @generated SignedSource<<e0d3aee05dfb52a0843a819120e89c7d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,6 +19,7 @@ final class IIntrospectionInterfaceA
   const keyset<string> FIELD_NAMES = keyset[
   ];
   const keyset<classname<Types\ObjectType>> POSSIBLE_TYPES = keyset[
+    ImplementInterfaceA::class,
     ImplementInterfaceB::class,
     ImplementInterfaceC::class,
   ];
@@ -37,6 +38,9 @@ final class IIntrospectionInterfaceA
     \Graphpinator\Parser\Field\IHasSelectionSet $field,
     GraphQL\Variables $vars,
   ): Awaitable<GraphQL\FieldResult<dict<string, mixed>>> {
+    if ($value is \ImplementInterfaceA) {
+      return await ImplementInterfaceA::nonNullable()->resolveAsync($value, $field, $vars);
+    }
     if ($value is \ImplementInterfaceB) {
       return await ImplementInterfaceB::nonNullable()->resolveAsync($value, $field, $vars);
     }

--- a/tests/gen/IIntrospectionInterfaceC.hack
+++ b/tests/gen/IIntrospectionInterfaceC.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<00ff8b3375bad51751b7ed4351089b61>>
+ * @generated SignedSource<<051b3e6063c6d8bc356b8668c0eec5bc>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -15,7 +15,7 @@ final class IIntrospectionInterfaceC
   extends \Slack\GraphQL\Types\InterfaceType {
 
   const NAME = 'IIntrospectionInterfaceC';
-  const type THackType = \IIntrospectionInterfaceC;
+  const type THackType = \IIntrospectionInterfaceCDifferentClassNameThanGraphQLType;
   const keyset<string> FIELD_NAMES = keyset[
   ];
   const keyset<classname<Types\ObjectType>> POSSIBLE_TYPES = keyset[

--- a/tests/gen/ImplementInterfaceA.hack
+++ b/tests/gen/ImplementInterfaceA.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<0b9e305b7922e55c884f72de5b268498>>
+ * @generated SignedSource<<53436dffd735452beaf52476eaf137fd>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -17,8 +17,8 @@ final class ImplementInterfaceA extends \Slack\GraphQL\Types\ObjectType {
   const type THackType = \ImplementInterfaceA;
   const keyset<string> FIELD_NAMES = keyset[
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
-    IIntrospectionInterfaceA::class,
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+    'IIntrospectionInterfaceA' => IIntrospectionInterfaceA::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ImplementInterfaceA.hack
+++ b/tests/gen/ImplementInterfaceA.hack
@@ -4,22 +4,21 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b933cfad342d40fb6d6a3a0ec45fd17c>>
+ * @generated SignedSource<<0b9e305b7922e55c884f72de5b268498>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
 use namespace HH\Lib\{C, Dict};
 
-final class ImplementInterfaceB extends \Slack\GraphQL\Types\ObjectType {
+final class ImplementInterfaceA extends \Slack\GraphQL\Types\ObjectType {
 
-  const NAME = 'ImplementInterfaceB';
-  const type THackType = \ImplementInterfaceB;
+  const NAME = 'ImplementInterfaceA';
+  const type THackType = \ImplementInterfaceA;
   const keyset<string> FIELD_NAMES = keyset[
   ];
   const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
     IIntrospectionInterfaceA::class,
-    IIntrospectionInterfaceB::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ImplementInterfaceB.hack
+++ b/tests/gen/ImplementInterfaceB.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b933cfad342d40fb6d6a3a0ec45fd17c>>
+ * @generated SignedSource<<9e0b3a4ffca4c305b94da9212f5b4b6f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -17,9 +17,9 @@ final class ImplementInterfaceB extends \Slack\GraphQL\Types\ObjectType {
   const type THackType = \ImplementInterfaceB;
   const keyset<string> FIELD_NAMES = keyset[
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
-    IIntrospectionInterfaceA::class,
-    IIntrospectionInterfaceB::class,
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+    'IIntrospectionInterfaceA' => IIntrospectionInterfaceA::class,
+    'IIntrospectionInterfaceB' => IIntrospectionInterfaceB::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ImplementInterfaceC.hack
+++ b/tests/gen/ImplementInterfaceC.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b746f756c5abd273a26f5ca35535fd0c>>
+ * @generated SignedSource<<11aa39f80b2881d293b3ecfb2c300565>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -17,10 +17,10 @@ final class ImplementInterfaceC extends \Slack\GraphQL\Types\ObjectType {
   const type THackType = \ImplementInterfaceC;
   const keyset<string> FIELD_NAMES = keyset[
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
-    IIntrospectionInterfaceA::class,
-    IIntrospectionInterfaceB::class,
-    IIntrospectionInterfaceC::class,
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+    'IIntrospectionInterfaceA' => IIntrospectionInterfaceA::class,
+    'IIntrospectionInterfaceB' => IIntrospectionInterfaceB::class,
+    'IIntrospectionInterfaceC' => IIntrospectionInterfaceC::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ImplementInterfaceC.hack
+++ b/tests/gen/ImplementInterfaceC.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<32df98f268157f6628aec2a6db2762d4>>
+ * @generated SignedSource<<b746f756c5abd273a26f5ca35535fd0c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -16,6 +16,11 @@ final class ImplementInterfaceC extends \Slack\GraphQL\Types\ObjectType {
   const NAME = 'ImplementInterfaceC';
   const type THackType = \ImplementInterfaceC;
   const keyset<string> FIELD_NAMES = keyset[
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+    IIntrospectionInterfaceA::class,
+    IIntrospectionInterfaceB::class,
+    IIntrospectionInterfaceC::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/IntrospectionTestObject.hack
+++ b/tests/gen/IntrospectionTestObject.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<249f444ee6347147a84866e39ae64853>>
+ * @generated SignedSource<<2ec633867a1874f20746329c497145ab>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -24,7 +24,7 @@ final class IntrospectionTestObject extends \Slack\GraphQL\Types\ObjectType {
     'non_null_string',
     'nullable_string',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/IntrospectionTestObject.hack
+++ b/tests/gen/IntrospectionTestObject.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<3265e2eae29f57617617f679a8411852>>
+ * @generated SignedSource<<249f444ee6347147a84866e39ae64853>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -23,6 +23,8 @@ final class IntrospectionTestObject extends \Slack\GraphQL\Types\ObjectType {
     'non_null_list_of_non_null',
     'non_null_string',
     'nullable_string',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Mutation.hack
+++ b/tests/gen/Mutation.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c3f6741e0f6e6b163c98bfd34059ccfe>>
+ * @generated SignedSource<<8effc458f88d700e19fc5f34452ec88f>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,7 +19,7 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
     'createUser',
     'pokeUser',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Mutation.hack
+++ b/tests/gen/Mutation.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e6cc33b0f4eb7dbb597cd43d1a0e6fa3>>
+ * @generated SignedSource<<c3f6741e0f6e6b163c98bfd34059ccfe>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -18,6 +18,8 @@ final class Mutation extends \Slack\GraphQL\Types\ObjectType {
   const keyset<string> FIELD_NAMES = keyset[
     'createUser',
     'pokeUser',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ObjectShape.hack
+++ b/tests/gen/ObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b65ebf52131aac2d95f68806d781cbf9>>
+ * @generated SignedSource<<e8c37f4133581e8ed57b442273b9c903>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,6 +19,8 @@ final class ObjectShape extends \Slack\GraphQL\Types\ObjectType {
     'foo',
     'bar',
     'baz',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/ObjectShape.hack
+++ b/tests/gen/ObjectShape.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e8c37f4133581e8ed57b442273b9c903>>
+ * @generated SignedSource<<4ee05a200f698afc8c2432c2a1b97359>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -20,7 +20,7 @@ final class ObjectShape extends \Slack\GraphQL\Types\ObjectType {
     'bar',
     'baz',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/OutputTypeTestObj.hack
+++ b/tests/gen/OutputTypeTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d76e4b7915817cb97e5f6e04d2bfd45f>>
+ * @generated SignedSource<<404dc3ce8faed5c64256f627f6a50cce>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -23,6 +23,8 @@ final class OutputTypeTestObj extends \Slack\GraphQL\Types\ObjectType {
     'nested_lists',
     'nullable',
     'scalar',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/OutputTypeTestObj.hack
+++ b/tests/gen/OutputTypeTestObj.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<404dc3ce8faed5c64256f627f6a50cce>>
+ * @generated SignedSource<<7072d90483f2cf38add1f2eacb8463d1>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -24,7 +24,7 @@ final class OutputTypeTestObj extends \Slack\GraphQL\Types\ObjectType {
     'nullable',
     'scalar',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Query.hack
+++ b/tests/gen/Query.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<e4ce6e7d308e7779fcc1ebbbc02d3e0d>>
+ * @generated SignedSource<<1e6b9390cb17561a6e151f20b6a150a8>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -36,7 +36,7 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
     'user',
     'viewer',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Query.hack
+++ b/tests/gen/Query.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<84fbd9df814af1ce3381be10fc335999>>
+ * @generated SignedSource<<e4ce6e7d308e7779fcc1ebbbc02d3e0d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -35,6 +35,8 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
     'takes_favorite_color',
     'user',
     'viewer',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<f029bf95ebc08fa6a47496c779cc1378>>
+ * @generated SignedSource<<5f4858747f3b720b51e05e0881999e0e>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -26,6 +26,7 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
     'IIntrospectionInterfaceA' => IIntrospectionInterfaceA::class,
     'IIntrospectionInterfaceB' => IIntrospectionInterfaceB::class,
     'IIntrospectionInterfaceC' => IIntrospectionInterfaceC::class,
+    'ImplementInterfaceA' => ImplementInterfaceA::class,
     'ImplementInterfaceB' => ImplementInterfaceB::class,
     'ImplementInterfaceC' => ImplementInterfaceC::class,
     'Int' => Types\IntType::class,

--- a/tests/gen/Team.hack
+++ b/tests/gen/Team.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<2fcbc3a984824eb80a25483803a45585>>
+ * @generated SignedSource<<0deff4fc095c8eb5aa9d081a87a6cf59>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -20,6 +20,8 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
     'id',
     'name',
     'num_users',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/Team.hack
+++ b/tests/gen/Team.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<0deff4fc095c8eb5aa9d081a87a6cf59>>
+ * @generated SignedSource<<42f8451c72c0c7713661e2da057f8902>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -21,7 +21,7 @@ final class Team extends \Slack\GraphQL\Types\ObjectType {
     'name',
     'num_users',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__EnumValue.hack
+++ b/tests/gen/__EnumValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<802276c16f369dd0037ca390373119c4>>
+ * @generated SignedSource<<82e7ee29e823bc36b9a7ecbacc30cec4>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -20,6 +20,8 @@ final class __EnumValue extends \Slack\GraphQL\Types\ObjectType {
     'description',
     'isDeprecated',
     'name',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__EnumValue.hack
+++ b/tests/gen/__EnumValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<82e7ee29e823bc36b9a7ecbacc30cec4>>
+ * @generated SignedSource<<f121838086bb0d72ad9cbc92b7497eed>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -21,7 +21,7 @@ final class __EnumValue extends \Slack\GraphQL\Types\ObjectType {
     'isDeprecated',
     'name',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__Field.hack
+++ b/tests/gen/__Field.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<eccd6e65f9eecabed94452fa86396e7a>>
+ * @generated SignedSource<<a4b858108eea9df3083e12d067650587>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,7 +19,7 @@ final class __Field extends \Slack\GraphQL\Types\ObjectType {
     'name',
     'type',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__Field.hack
+++ b/tests/gen/__Field.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<037bfbdb594fcb15248df7a37a26c6f9>>
+ * @generated SignedSource<<eccd6e65f9eecabed94452fa86396e7a>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -18,6 +18,8 @@ final class __Field extends \Slack\GraphQL\Types\ObjectType {
   const keyset<string> FIELD_NAMES = keyset[
     'name',
     'type',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__InputValue.hack
+++ b/tests/gen/__InputValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<ca7ef47d708e8c44672e7ec1996bcdc7>>
+ * @generated SignedSource<<d4a8b8d680bf78c9c3646e48c703e7dc>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -21,7 +21,7 @@ final class __InputValue extends \Slack\GraphQL\Types\ObjectType {
     'name',
     'type',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__InputValue.hack
+++ b/tests/gen/__InputValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<a4fcf34b2f0d64dcaf8492c77090ab03>>
+ * @generated SignedSource<<ca7ef47d708e8c44672e7ec1996bcdc7>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -20,6 +20,8 @@ final class __InputValue extends \Slack\GraphQL\Types\ObjectType {
     'description',
     'name',
     'type',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__Schema.hack
+++ b/tests/gen/__Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d4671af9a4b12c09959f69533ec760a5>>
+ * @generated SignedSource<<c3e266bc76b2b2312f8415a1f35a8117>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -18,6 +18,8 @@ final class __Schema extends \Slack\GraphQL\Types\ObjectType {
   const keyset<string> FIELD_NAMES = keyset[
     'mutationType',
     'queryType',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__Schema.hack
+++ b/tests/gen/__Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c3e266bc76b2b2312f8415a1f35a8117>>
+ * @generated SignedSource<<85b451e5cd0c1245ad4c6862aef089f9>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,7 +19,7 @@ final class __Schema extends \Slack\GraphQL\Types\ObjectType {
     'mutationType',
     'queryType',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__Type.hack
+++ b/tests/gen/__Type.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<4e1bfb13121b83b22d98d3bc73b26c8e>>
+ * @generated SignedSource<<d5b292e625c90b26733cf7542f70dc4a>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -25,6 +25,8 @@ final class __Type extends \Slack\GraphQL\Types\ObjectType {
     'name',
     'ofType',
     'possibleTypes',
+  ];
+  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/__Type.hack
+++ b/tests/gen/__Type.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d5b292e625c90b26733cf7542f70dc4a>>
+ * @generated SignedSource<<09209020c33d8df06c4c39667cbcdbef>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -26,7 +26,7 @@ final class __Type extends \Slack\GraphQL\Types\ObjectType {
     'ofType',
     'possibleTypes',
   ];
-  const keyset<classname<Types\InterfaceType>> INTERFACES = keyset[
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
 
   public function getFieldDefinition(


### PR DESCRIPTION
Same flow as possible types on an interface. Biggest change was needing to swap to collect all interfaces before building objects.