### PR TITLE
Pagination

### DIFF
--- a/src/Codegen/Builders/CompositeBuilder.hack
+++ b/src/Codegen/Builders/CompositeBuilder.hack
@@ -15,13 +15,12 @@ use type Facebook\HackCodegen\{
  *
  * The annotated Hack type should be either a class, interface, or shape.
  */
-abstract class CompositeBuilder<TField as IFieldBuilder>
-    extends OutputTypeBuilder<\Slack\GraphQL\__Private\CompositeType> {
+abstract class CompositeBuilder extends OutputTypeBuilder<\Slack\GraphQL\__Private\CompositeType> {
 
     public function __construct(
         \Slack\GraphQL\__Private\CompositeType $type_info,
         string $hack_type,
-        protected vec<TField> $fields,
+        protected vec<FieldBuilder> $fields,
     ) {
         parent::__construct($type_info, $hack_type);
     }

--- a/src/Codegen/Builders/Fields/ConnectionFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/ConnectionFieldBuilder.hack
@@ -1,0 +1,66 @@
+namespace Slack\GraphQL\Codegen;
+
+use namespace HH\Lib\{C, Str, Vec};
+use type Facebook\HackCodegen\{HackBuilder, HackBuilderValues};
+
+/**
+ * A special-case field builder which handles creating GraphQL fields which return connections.
+ * Since connections accept arguments which are not passed into the user-defined method, we need
+ * to set these arguments on the connection after calling the user-defined method. This is a hack.
+ */
+final class ConnectionFieldBuilder extends MethodFieldBuilder {
+    <<__Override>>
+    protected function generateResolverBody(HackBuilder $hb): void {
+        $needs_await = $this->data['output_type']['needs_await'] ?? false;
+        if ($needs_await) {
+            // Wrap the async function call in parenthesis so we can chain off the return value.
+            $hb->add('(');
+        }
+        parent::generateResolverBody($hb);
+        if ($needs_await) {
+            $hb->add(')');
+        }
+        $hb->addLine('->setPaginationArgs(')->indent();
+        foreach ($this->getConnectionParameters() as $param) {
+            $hb->addLinef('%s,', $this->getArgumentInvocationString($param));
+        }
+        $hb->unindent()->add(')');
+    }
+
+    <<__Override>>
+    protected function getArgumentDefinitions(): vec<Parameter> {
+        return Vec\concat($this->data['parameters'], $this->getConnectionParameters());
+    }
+
+    /**
+     * Arguments set on the connection after it's been returned from the user-defined method.
+     */
+    protected function getConnectionParameters(): vec<Parameter> {
+        return vec[
+            shape(
+                'name' => 'after',
+                'type' => '?HH\string',
+                'is_optional' => true,
+                'default_value' => 'null',
+            ),
+            shape(
+                'name' => 'before',
+                'type' => '?HH\string',
+                'is_optional' => true,
+                'default_value' => 'null',
+            ),
+            shape(
+                'name' => 'first',
+                'type' => '?HH\int',
+                'is_optional' => true,
+                'default_value' => 'null',
+            ),
+            shape(
+                'name' => 'last',
+                'type' => '?HH\int',
+                'is_optional' => true,
+                'default_value' => 'null',
+            ),
+        ];
+    }
+}

--- a/src/Codegen/Builders/Fields/FieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/FieldBuilder.hack
@@ -1,0 +1,148 @@
+namespace Slack\GraphQL\Codegen;
+
+use namespace HH\Lib\{C, Str, Vec};
+use type Facebook\HackCodegen\{HackBuilder, HackBuilderValues};
+
+/**
+ * Base builder for constructing GraphQL fields.
+ */
+abstract class FieldBuilder {
+
+    abstract const type TField as shape(
+        'name' => string,
+        'output_type' => shape('type' => string, ?'needs_await' => bool),
+        'declaring_type' => string,
+        ...
+    );
+
+    public function getName(): string {
+        return $this->data['name'];
+    }
+
+    // Constructors
+
+    public function __construct(protected this::TField $data) {}
+
+    /**
+     * Construct a GraphQL field from a Hack method.
+     */
+    public static function fromReflectionMethod(
+        \Slack\GraphQL\Field $field,
+        \ReflectionMethod $rm,
+        bool $is_root_field = false,
+    ): FieldBuilder {
+        $data = shape(
+            'name' => $field->getName(),
+            'method_name' => $rm->getName(),
+            'declaring_type' => $rm->getDeclaringClass()->getName(),
+            'is_root_field' => $is_root_field,
+            'output_type' => output_type(
+                $rm->getReturnTypeText(),
+                $rm->getAttributeClass(\Slack\GraphQL\KillsParentOnException::class) is nonnull,
+            ),
+            'parameters' => Vec\map(
+                $rm->getParameters(),
+                $param ==> {
+                    $data = shape(
+                        'name' => $param->getName(),
+                        'type' => $param->getTypeText(),
+                        'is_optional' => $param->isOptional(),
+                    );
+                    if ($param->isOptional()) {
+                        $data['default_value'] = $param->getDefaultValueText();
+                    }
+                    return $data;
+                },
+            ),
+        );
+
+        if (returns_connection_type($rm)) {
+            return new ConnectionFieldBuilder($data);
+        } else {
+            return new MethodFieldBuilder($data);
+        }
+    }
+
+    /**
+     * Construct a GraphQL field from a shape field.
+     */
+    public static function fromShapeField<T>(string $name, string $declaring_type, TypeStructure<T> $ts): FieldBuilder {
+        return new ShapeFieldBuilder(shape(
+            'name' => $name,
+            'output_type' => output_type(type_structure_to_type_alias($ts), false),
+            'declaring_type' => $declaring_type,
+            'is_optional' => Shapes::idx($ts, 'optional_shape_field') ?? false,
+        ));
+    }
+
+    /**
+     * Construct a top-level GraphQL field.
+     */
+    public static function forRootField(\Slack\GraphQL\Field $field, \ReflectionMethod $rm): FieldBuilder {
+        return FieldBuilder::fromReflectionMethod($field, $rm, true);
+    }
+
+    // Codegen
+
+    /**
+     * Get arguments definitions for this GQL field.
+     */
+    abstract protected function getArgumentDefinitions(): vec<Parameter>;
+
+    /**
+     * Generate the body of the resolver callback.
+     */
+    abstract protected function generateResolverBody(HackBuilder $hb): void;
+
+    public function addGetFieldDefinitionCase(HackBuilder $hb): void {
+        $hb->addCase($this->data['name'], HackBuilderValues::export());
+
+        $hb->addLine('return new GraphQL\\FieldDefinition(')->indent();
+
+        // Field name
+        $name_literal = \var_export($this->data['name'], true);
+        $hb->addLinef('%s,', $name_literal);
+
+        // Field return type
+        $type_info = $this->data['output_type'];
+        $hb->addLinef('%s,', $type_info['type']);
+
+        // Argument Definitions
+        $this->generateArgumentDefinitions($hb);
+
+        // Resolver
+        $hb->add('async ($parent, $args, $vars) ==> ');
+        $this->generateResolverBody($hb);
+        $hb->addLine(',');
+
+        // End of new GraphQL\FieldDefinition(
+        $hb->unindent()->addLine(');');
+        $hb->unindent();
+    }
+
+    private function generateArgumentDefinitions(HackBuilder $hb): void {
+        $argument_defintions = $this->getArgumentDefinitions();
+        if ($argument_defintions) {
+            $hb->addLine('dict[')->indent();
+            foreach ($argument_defintions as $param) {
+                $argument_name = \var_export($param['name'], true);
+                $hb->addLinef('%s => shape(', $argument_name)->indent();
+
+                $hb->addLinef("'name' => %s,", $argument_name);
+
+                $type = input_type($param['type']);
+                $hb->addLinef("'type' => %s,", $type);
+
+                $default_value = $param['default_value'] ?? null;
+                if ($default_value is nonnull) {
+                    $hb->addLinef("'default_value' => %s,", $default_value);
+                }
+
+                $hb->unindent()->addLine('),');
+            }
+            $hb->unindent()->addLine('],');
+        } else {
+            $hb->addLine('dict[],');
+        }
+    }
+}

--- a/src/Codegen/Builders/Fields/IFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/IFieldBuilder.hack
@@ -1,8 +1,0 @@
-namespace Slack\GraphQL\Codegen;
-
-use type Facebook\HackCodegen\HackBuilder;
-
-interface IFieldBuilder {
-    public function addGetFieldDefinitionCase(HackBuilder $hb): void;
-    public function getName(): string;
-}

--- a/src/Codegen/Builders/Fields/StaticFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/StaticFieldBuilder.hack
@@ -1,9 +1,0 @@
-namespace Slack\GraphQL\Codegen;
-
-class StaticFieldBuilder extends MethodFieldBuilder {
-    <<__Override>>
-    protected function getMethodCallPrefix(): string {
-        $class = $this->reflection_method->getDeclaringClass();
-        return '\\'.$class->getName().'::';
-    }
-}

--- a/src/Codegen/Builders/InterfaceBuilder.hack
+++ b/src/Codegen/Builders/InterfaceBuilder.hack
@@ -9,14 +9,14 @@ use type Facebook\HackCodegen\{
     HackBuilderValues,
 };
 
-final class InterfaceBuilder<TField as IFieldBuilder> extends CompositeBuilder<TField> {
+final class InterfaceBuilder extends CompositeBuilder {
     const classname<\Slack\GraphQL\Types\InterfaceType> SUPERCLASS = \Slack\GraphQL\Types\InterfaceType::class;
 
     <<__Override>>
     public function __construct(
         \Slack\GraphQL\__Private\CompositeType $type_info,
         string $hack_type,
-        vec<TField> $fields,
+        vec<FieldBuilder> $fields,
         private dict<string, string> $hack_class_to_graphql_object,
     ) {
         parent::__construct($type_info, $hack_type, $fields);

--- a/src/Codegen/Builders/ObjectBuilder.hack
+++ b/src/Codegen/Builders/ObjectBuilder.hack
@@ -75,20 +75,21 @@ class ObjectBuilder extends CompositeBuilder {
                         'needs_await' => true,
                     ),
                     'declaring_type' => $name,
-                    'parameters' => vec[]
+                    'parameters' => vec[],
                 )),
                 new MethodFieldBuilder(shape(
                     'name' => 'pageInfo',
                     'method_name' => 'getPageInfo',
                     'output_type' => shape('type' => 'PageInfo::nullableOutput()', 'needs_await' => true),
                     'declaring_type' => $name,
-                    'parameters' => vec[]
+                    'parameters' => vec[],
                 )),
             ],
             dict[], // Connections do not implement any interfaces
         );
     }
 
+    // TODO: It should be possible to create user-defined edges which contain additional fields.
     public static function forEdge(string $hack_type): ObjectBuilder {
         $name = $hack_type.'Edge';
         return new ObjectBuilder(

--- a/src/Codegen/Builders/ObjectBuilder.hack
+++ b/src/Codegen/Builders/ObjectBuilder.hack
@@ -62,7 +62,7 @@ class ObjectBuilder extends CompositeBuilder {
         );
     }
 
-    public static function forConnection(string $name): ObjectBuilder {
+    public static function forConnection(string $name, string $edge_name): ObjectBuilder {
         return new ObjectBuilder(
             new \Slack\GraphQL\ObjectType($name, $name), // TODO: Description
             $name,  // hack type
@@ -71,7 +71,7 @@ class ObjectBuilder extends CompositeBuilder {
                     'name' => 'edges',
                     'method_name' => 'getEdges',
                     'output_type' => shape(
-                        'type' => 'UserEdge::nonNullable()->nullableOutputListOf()',
+                        'type' => $edge_name.'::nonNullable()->nullableOutputListOf()',
                         'needs_await' => true,
                     ),
                     'declaring_type' => $name,

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -245,6 +245,12 @@ final class Generator {
                 $type_param = $rc->getTypeConstants()
                     |> C\find($$, $c ==> $c->getName() === 'TNode')?->getAssignedTypeText();
                 invariant($type_param is nonnull, '%s must declare a type constant "TNode"', $rc->getName());
+                invariant(
+                    get_output_class($type_param) is nonnull,
+                    'Node type "%s" for "%s" must be a valid GraphQL output type',
+                    $type_param,
+                    $rc->getName()
+                );
                 $objects[] = ObjectBuilder::forConnection($class->getName(), $type_param.'Edge');
                 $objects[] = ObjectBuilder::forEdge($type_param);
             } elseif (!C\is_empty($class->getAttributes())) {

--- a/src/Codegen/MultiParser.hack
+++ b/src/Codegen/MultiParser.hack
@@ -1,0 +1,35 @@
+namespace Slack\GraphQL\Codegen;
+
+use namespace HH\Lib\Vec;
+use namespace Facebook\DefinitionFinder;
+
+/**
+ * Parser which allows for aggregating a set of parsers and operating them in unison.
+ */
+final class MultiParser {
+    public function __construct(private vec<DefinitionFinder\BaseParser> $parsers) {}
+
+    private function mapParsers<T>((function (DefinitionFinder\BaseParser): vec<T>) $cb): vec<T> {
+        return Vec\map($this->parsers, $parser ==> $cb($parser)) |> Vec\flatten($$);
+    }
+
+    public function getTypes(): vec<DefinitionFinder\ScannedType> {
+        return $this->mapParsers($parser ==> $parser->getTypes());
+    }
+
+    public function getClasses(): vec<DefinitionFinder\ScannedClass> {
+        return $this->mapParsers($parser ==> $parser->getClasses());
+    }
+
+    public function getInterfaces(): vec<DefinitionFinder\ScannedInterface> {
+        return $this->mapParsers($parser ==> $parser->getInterfaces());
+    }
+
+    public function getEnums(): vec<DefinitionFinder\ScannedEnum> {
+        return $this->mapParsers($parser ==> $parser->getEnums());
+    }
+
+    public function getClassishObjects(): vec<DefinitionFinder\ScannedClassish> {
+        return Vec\concat($this->getClasses(), $this->getInterfaces());
+    }
+}

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -1,0 +1,204 @@
+namespace Slack\GraphQL\Pagination;
+
+use namespace HH\Lib\{C, Vec};
+use namespace Slack\GraphQL;
+
+/**
+ * Arguments passed to a connection's `paginate` method. These should be used to determine the result set.
+ *
+ * The framework ensures that at most one of `first` and `last` is provided.
+ */
+type PaginationArgs = shape(
+
+    /**
+     * If provided, only retrieve items which come before this cursor in the dataset.
+     */
+    ?'before' => string,
+
+    /**
+     * If provided, only retrieve items which come after this cursor in the dataset.
+     */
+    ?'after' => string,
+
+    /**
+     * If provided, only retrieve the first `first` items which appear after the `after` cursor or,
+     * if the `after` cursor was not provided, after the first item in the dataset.
+     */
+    ?'first' => int,
+
+    /**
+     * If provided, only retrieve the last `last` items which appear before the `before` cursor or,
+     * if the `before` cursor was not provided, before the last item in the dataset.
+     */
+    ?'last' => int,
+);
+
+/**
+ * `Connection` provides a standard mechanism for slicing and paginating querysets, as well as for providing cursors
+ * and informing the client when more results are available.
+ *
+ * Each connection paginates over a generic type `T`. `T` must be a Hack type which has a GraphQL representation that
+ * is not a list type. To paginate over a type `T`, subclass `Connection` and implement the `paginate` and `getCursor` 
+ * methods. While `Connection` is purposely simple so as to support a wide variety of data sources, you're encouraged 
+ * to create reusable subclasses which connect to the data sources you use.
+ *
+ * @see https://relay.dev/graphql/connections.htm for more information about GraphQL pagination.
+ * @see src/playground/UserConnection.hack for an example.
+ */
+abstract class Connection<T> {
+
+    /**
+     * Paginate the data set per the pagination args, which contain cursors and limits.
+     *
+     * For example, if the pagination args contain a `before` cursor with value `foo` and a `last` limit with value 5, 
+     * `paginate` should return the 5 items immediately prior to the item with cursor `foo` in the dataset.
+     */
+    abstract protected function paginate(PaginationArgs $args): Awaitable<vec<T>>;
+
+    /**
+     * Given an instance of the Hack type over which this connection provides pagination, retrieve a cursor which 
+     * identifies that instance. The framework will encode the cursor before passing it to the client.
+     */
+    abstract public function getCursor(T $item): string;
+
+    /**
+     * Encode a cursor before transmitting it to the client.
+     *
+     * By default, cursors are base64 encoded. Override this method to change that.
+     */
+    public function encodeCursor(string $cursor): string {
+        return \base64_encode($cursor);
+    }
+
+    /**
+     * Decode a cursor upon receiving it from the client.
+     *
+     * By default, cursors are base64 encoded. If you change that, you'll need to override this method.
+     */
+    public function decodeCursor(string $cursor): string {
+        return \base64_decode($cursor);
+    }
+
+    /**
+     * Whether a page exists before the `after` cursor, was such a cursor provided.
+     * As this often cannot be determined efficiently, this method returns false by default.
+     */
+    public async function hasPageBeforeAfterCursor(string $after_cursor): Awaitable<bool> {
+        return false;
+    }
+
+    /**
+     * Whether a page exists after the `before` cursor, was such a cursor provided.
+     * As this cannot often be determined efficiently, this method returns false by default.
+     */
+    public async function hasPageAfterBeforeCursor(string $before_cursor): Awaitable<bool> {
+        return false;
+    }
+
+    //
+    // Implementation Details
+    //
+
+    private PaginationArgs $args = shape();
+
+    /**
+     * Called by the framework to set pagination args immediately after receiving a connection from a resolver.
+     *
+     * These args are not passed to resolvers directly, so framework users need only handle them when implementing
+     * the `paginate` method, and then after they've been coerced to the more amenable `PaginationArgs` shape.
+     */
+    public function setPaginationArgs(?string $after, ?string $before, ?int $first, ?int $last): this {
+        $args = shape();
+
+        if ($first is nonnull && $last is nonnull) {
+            // We might relax this requirement at some point.
+            // For now, handling both `first` and `last` at the same time is more trouble than it's worth.
+            throw new GraphQL\UserFacingError('Only provide one of either "first" or "last".');
+        } elseif ($first is nonnull) {
+            if ($first < 0) {
+                throw new GraphQL\UserFacingError('"first" must be a non-negative integer.');
+            }
+            // Always fetch an extra item so we can efficiently determine if there's a next page.
+            $args['first'] = $first + 1;
+        } elseif ($last is nonnull) {
+            if ($last < 0) {
+                throw new GraphQL\UserFacingError('"last" must be a non-negative integer.');
+            }
+            // Always fetch an extra item so we can efficiently determine if there's a prior page.
+            $args['last'] = $last + 1;
+        }
+
+        // Decode cursors
+        if ($after is nonnull) {
+            $args['after'] = $this->decodeCursor($after);
+        }
+        if ($before is nonnull) {
+            $args['before'] = $this->decodeCursor($before);
+        }
+
+        $this->args = $args;
+
+        return $this;
+    }
+
+    /**
+     * Constuct the correct edges and pageInfo objects from the result of calling the user-implemented `paginate` 
+     * method with the pagination args.
+     */
+    <<__Memoize>>
+    final private async function doPaginate(): Awaitable<shape('edges' => vec<Edge<T>>, 'pageInfo' => PageInfo)> {
+        $page = await $this->paginate($this->args);
+
+        $page_info = shape();
+
+        // Determine whether more results are available by checking whether the number of items returned from
+        // `paginate` is more than the number of items requested by the client. We always request one more item
+        // than the client requested so as to simplify this calculation.
+
+        $first = $this->args['first'] ?? null;
+        if ($first is nonnull) {
+            $page_info['hasNextPage'] = C\count($page) > $first - 1;
+            if (Shapes::keyExists($this->args, 'after')) {
+                $page_info['hasPreviousPage'] = await $this->hasPageBeforeAfterCursor($this->args['after']);
+            }
+            $page = Vec\take($page, $first - 1);
+        }
+
+        $last = $this->args['last'] ?? null;
+        if ($last is nonnull) {
+            $page_info['hasPreviousPage'] = C\count($page) > $last - 1;
+            if (Shapes::keyExists($this->args, 'before')) {
+                $page_info['hasNextPage'] = await $this->hasPageAfterBeforeCursor($this->args['before']);
+            }
+            $page = Vec\drop($page, 1);
+        }
+
+        // Set the start and end cursors if the query had results.
+        if (!C\is_empty($page)) {
+            $page_info['startCursor'] = $this->encodeCursor($this->getCursor(C\firstx($page)));
+            $page_info['endCursor'] = $this->encodeCursor($this->getCursor(C\lastx($page)));
+        }
+
+        $edges = Vec\map($page, $item ==> new Edge($item, $this));
+
+        return shape('edges' => $edges, 'pageInfo' => $page_info);
+    }
+
+    /**
+     * Get edges containing nodes of type `T`.
+     * This is the method invoked when querying the `edges` field on a connection.
+     */
+    final public async function getEdges(): Awaitable<vec<Edge<T>>> {
+        $ret = await $this->doPaginate();
+        return $ret['edges'];
+    }
+
+    /**
+     * Get page info for this connection.
+     * This is the method invoked when querying the `pageInfo` field on a connection.
+     */
+    final public async function getPageInfo(): Awaitable<PageInfo> {
+        $ret = await $this->doPaginate();
+        return $ret['pageInfo'];
+    }
+}

--- a/src/Pagination/Edge.hack
+++ b/src/Pagination/Edge.hack
@@ -4,9 +4,9 @@ namespace Slack\GraphQL\Pagination;
  * Wraps an instance of a Hack type which has a non-list GraphQL representation, providing access to the underlying
  * instance as well as to the cursor identifying the instance in the dataset.
  */
-final class Edge<T> {
+class Edge<T> {
 
-    public function __construct(private T $node, private Connection<T> $connection) {}
+    public function __construct(private T $node, private string $cursor) {}
 
     /**
      * Get the node pointed to by this edge.
@@ -21,7 +21,6 @@ final class Edge<T> {
      * This is the method invoked when querying the `cursor` field on a GraphQL edge.
      */
     public function getCursor(): string {
-        $cursor = $this->connection->getCursor($this->node);
-        return $this->connection->encodeCursor($cursor);
+        return $this->cursor;
     }
 }

--- a/src/Pagination/Edge.hack
+++ b/src/Pagination/Edge.hack
@@ -1,0 +1,27 @@
+namespace Slack\GraphQL\Pagination;
+
+/**
+ * Wraps an instance of a Hack type which has a non-list GraphQL representation, providing access to the underlying
+ * instance as well as to the cursor identifying the instance in the dataset.
+ */
+final class Edge<T> {
+
+    public function __construct(private T $node, private Connection<T> $connection) {}
+
+    /**
+     * Get the node pointed to by this edge.
+     * This is the method invoked when querying the `node` field on a GraphQL edge.
+     */
+    public function getNode(): T {
+        return $this->node;
+    }
+
+    /**
+     * Get the cursor identifying the node wrapped by this edge.
+     * This is the method invoked when querying the `cursor` field on a GraphQL edge.
+     */
+    public function getCursor(): string {
+        $cursor = $this->connection->getCursor($this->node);
+        return $this->connection->encodeCursor($cursor);
+    }
+}

--- a/src/Pagination/PageInfo.hack
+++ b/src/Pagination/PageInfo.hack
@@ -1,0 +1,27 @@
+namespace Slack\GraphQL\Pagination;
+
+use namespace Slack\GraphQL;
+
+<<GraphQL\ObjectType('PageInfo', 'Info about the pagination state.')>>
+type PageInfo = shape(
+
+    /**
+     * The first cursor in the dataset returned to the client.
+     */
+    ?'startCursor' => string,
+
+    /**
+     * The last cursor in the dataset returned to the client.
+     */
+    ?'endCursor' => string,
+
+    /**
+     * Whether at least one cursor exists prior to the `startCursor`.
+     */
+    ?'hasPreviousPage' => bool,
+
+    /**
+     * Whether at least one cursor exists after the `endCursor`.
+     */
+    ?'hasNextPage' => bool,
+);

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -1,5 +1,5 @@
 use namespace Slack\GraphQL;
-use namespace HH\Lib\{Math, Vec};
+use namespace HH\Lib\{Math, Str, Vec};
 
 <<GraphQL\InputObjectType('CreateTeamInput', 'Arguments for creating a team')>>
 type TCreateTeamInput = shape(
@@ -96,6 +96,11 @@ final class Human extends BaseUser {
     <<GraphQL\Field('favorite_color', 'Favorite color of the user')>>
     public function getFavoriteColor(): FavoriteColor {
         return FavoriteColor::BLUE;
+    }
+
+    <<GraphQL\Field('friends', 'Friends')>>
+    public async function getFriends(): Awaitable<UserConnection> {
+        return new UserConnection();
     }
 }
 

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -102,6 +102,11 @@ final class Human extends BaseUser {
     public async function getFriends(): Awaitable<UserConnection> {
         return new UserConnection();
     }
+
+    <<GraphQL\Field('named_friends', 'Test that we can pass args to a field which returns a connection')>>
+    public async function getFriendsWithArg(string $name_prefix): Awaitable<UserConnection> {
+        return new UserConnection($name_prefix);
+    }
 }
 
 <<GraphQL\ObjectType('Bot', 'Bot')>>

--- a/src/playground/UserConnection.hack
+++ b/src/playground/UserConnection.hack
@@ -1,8 +1,12 @@
 use namespace Slack\GraphQL;
 use namespace HH\Lib\{Math, Str};
 
-final class UserConnection extends GraphQL\Pagination\Connection<User> {
-    protected async function paginate(
+final class UserConnection extends GraphQL\Pagination\Connection {
+    const type TNode = User;
+
+    public function __construct(private string $name_prefix = 'User') {}
+
+    protected async function fetch(
         GraphQL\Pagination\PaginationArgs $args,
     ): Awaitable<vec<GraphQL\Pagination\Edge<User>>> {
         $after = $args['after'] ?? null;
@@ -32,7 +36,7 @@ final class UserConnection extends GraphQL\Pagination\Connection<User> {
             $edges[] = new GraphQL\Pagination\Edge(
                 new Human(shape(
                     'id' => $i,
-                    'name' => 'User '.$i,
+                    'name' => $this->name_prefix.' '.$i,
                     'team_id' => 1,
                     'is_active' => $i % 2 === 0 ? true : false,
                 )),

--- a/src/playground/UserConnection.hack
+++ b/src/playground/UserConnection.hack
@@ -1,0 +1,44 @@
+use namespace Slack\GraphQL;
+use namespace HH\Lib\{Math, Str};
+
+final class UserConnection extends GraphQL\Pagination\Connection<User> {
+    protected async function paginate(GraphQL\Pagination\PaginationArgs $args): Awaitable<vec<User>> {
+        $after = $args['after'] ?? null;
+        $start_id = 0;
+        if ($after) {
+            $start_id = Str\to_int($after) as nonnull + 1;  // Add one to skip the `after` cursor.
+        }
+
+        $before = $args['before'] ?? null;
+        $end_id = 5;
+        if ($before) {
+            $end_id = Str\to_int($before) as nonnull;
+        }
+
+        $first = $args['first'] ?? null;
+        if ($first) {
+            $end_id = Math\minva($end_id, $start_id + $first);
+        }
+
+        $last = $args['last'] ?? null;
+        if ($last) {
+            $start_id = Math\maxva($start_id, $end_id - $last);
+        }
+
+        $users = vec[];
+        for ($i = $start_id; $i < $end_id; $i++) {
+            $users[] = new Human(shape(
+                'id' => $i,
+                'name' => 'User '.$i,
+                'team_id' => 1,
+                'is_active' => $i % 2 === 0 ? true : false
+            ));
+        }
+
+        return $users;
+    }
+
+    public function getCursor(User $user): string {
+        return (string)$user->getId();
+    }
+}

--- a/tests/PaginationTest.hack
+++ b/tests/PaginationTest.hack
@@ -36,14 +36,14 @@ final class PaginationTest extends PlaygroundTest {
                             'edges' => vec[
                                 dict[
                                     'node' => dict[
-                                        'id' => '2',
+                                        'id' => 2,
                                         'name' => 'User 2',
                                     ],
                                     'cursor' => base64_encode('2'),
                                 ],
                                 dict[
                                     'node' => dict[
-                                        'id' => '3',
+                                        'id' => 3,
                                         'name' => 'User 3',
                                     ],
                                     'cursor' => base64_encode('3'),
@@ -52,11 +52,53 @@ final class PaginationTest extends PlaygroundTest {
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
                                 'startCursor' => base64_encode('2'),
-                                'endCursor' => base64_encode('3')
+                                'endCursor' => base64_encode('3'),
                             ]
                         ]
                     ]
                 ]
+            ),
+
+            'test retrieving the last edges in the dataset' => tuple(
+                'query ($after: String!) {
+                    human(id: 20) {
+                        friends(after: $after, first: 2) {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasNextPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict['after' => base64_encode("3")],
+                dict[
+                    'human' => dict[
+                        'friends' => dict[
+                            'edges' => vec[
+                                dict[
+                                    'node' => dict[
+                                        'id' => 4,
+                                        'name' => 'User 4',
+                                    ],
+                                    'cursor' => base64_encode('4'),
+                                ],
+                            ],
+                            'pageInfo' => dict[
+                                'hasNextPage' => false,
+                                'startCursor' => base64_encode('4'),
+                                'endCursor' => base64_encode('4'),
+                            ],
+                        ],
+                    ],
+                ],
             ),
 
             'test retrieving edges before an index' => tuple(
@@ -85,14 +127,14 @@ final class PaginationTest extends PlaygroundTest {
                             'edges' => vec[
                                 dict[
                                     'node' => dict[
-                                        'id' => '2',
+                                        'id' => 2,
                                         'name' => 'User 2',
                                     ],
                                     'cursor' => base64_encode('2'),
                                 ],
                                 dict[
                                     'node' => dict[
-                                        'id' => '3',
+                                        'id' => 3,
                                         'name' => 'User 3',
                                     ],
                                     'cursor' => base64_encode('3'),
@@ -101,11 +143,11 @@ final class PaginationTest extends PlaygroundTest {
                             'pageInfo' => dict[
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('2'),
-                                'endCursor' => base64_encode('3')
-                            ]
-                        ]
-                    ]
-                ]
+                                'endCursor' => base64_encode('3'),
+                            ],
+                        ],
+                    ],
+                ],
             ),
 
             'test providing first without after' => tuple(
@@ -134,14 +176,14 @@ final class PaginationTest extends PlaygroundTest {
                             'edges' => vec[
                                 dict[
                                     'node' => dict[
-                                        'id' => '0',
+                                        'id' => 0,
                                         'name' => 'User 0',
                                     ],
                                     'cursor' => base64_encode('0'),
                                 ],
                                 dict[
                                     'node' => dict[
-                                        'id' => '1',
+                                        'id' => 1,
                                         'name' => 'User 1',
                                     ],
                                     'cursor' => base64_encode('1'),
@@ -150,11 +192,53 @@ final class PaginationTest extends PlaygroundTest {
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
                                 'startCursor' => base64_encode('0'),
-                                'endCursor' => base64_encode('1')
-                            ]
-                        ]
-                    ]
-                ]
+                                'endCursor' => base64_encode('1'),
+                            ],
+                        ],
+                    ],
+                ],
+            ),
+
+            'test retrieving the first edges in the dataset' => tuple(
+                'query ($before: String!) {
+                    human(id: 20) {
+                        friends(before: $before, last: 2) {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasPreviousPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict['before' => base64_encode("1")],
+                dict[
+                    'human' => dict[
+                        'friends' => dict[
+                            'edges' => vec[
+                                dict[
+                                    'node' => dict[
+                                        'id' => 0,
+                                        'name' => 'User 0',
+                                    ],
+                                    'cursor' => base64_encode('0'),
+                                ],
+                            ],
+                            'pageInfo' => dict[
+                                'hasPreviousPage' => false,
+                                'startCursor' => base64_encode('0'),
+                                'endCursor' => base64_encode('0'),
+                            ],
+                        ],
+                    ],
+                ],
             ),
 
             'test providing last without before' => tuple(
@@ -183,14 +267,14 @@ final class PaginationTest extends PlaygroundTest {
                             'edges' => vec[
                                 dict[
                                     'node' => dict[
-                                        'id' => '3',
+                                        'id' => 3,
                                         'name' => 'User 3',
                                     ],
                                     'cursor' => base64_encode('3'),
                                 ],
                                 dict[
                                     'node' => dict[
-                                        'id' => '4',
+                                        'id' => 4,
                                         'name' => 'User 4',
                                     ],
                                     'cursor' => base64_encode('4'),
@@ -199,11 +283,53 @@ final class PaginationTest extends PlaygroundTest {
                             'pageInfo' => dict[
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('3'),
-                                'endCursor' => base64_encode('4')
-                            ]
-                        ]
-                    ]
-                ]
+                                'endCursor' => base64_encode('4'),
+                            ],
+                        ],
+                    ],
+                ],
+            ),
+
+            'test passing additional args to a connection field' => tuple(
+                'query {
+                    human(id: 20) {
+                        named_friends(first: 1, name_prefix: "Bob") {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasNextPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    'human' => dict[
+                        'named_friends' => dict[
+                            'edges' => vec[
+                                dict[
+                                    'node' => dict[
+                                        'id' => 0,
+                                        'name' => 'Bob 0',
+                                    ],
+                                    'cursor' => base64_encode('0'),
+                                ],
+                            ],
+                            'pageInfo' => dict[
+                                'hasNextPage' => true,
+                                'startCursor' => base64_encode('0'),
+                                'endCursor' => base64_encode('0'),
+                            ],
+                        ],
+                    ],
+                ],
             ),
 
             'test providing both last and first' => tuple(
@@ -238,8 +364,8 @@ final class PaginationTest extends PlaygroundTest {
                             'path' => vec['human', 'friends'],
                         ),
                     ],
-                )
-            )
+                ),
+            ),
         ];
     }
 }

--- a/tests/PaginationTest.hack
+++ b/tests/PaginationTest.hack
@@ -1,0 +1,245 @@
+use function Facebook\FBExpect\expect;
+use namespace HH\Lib\C;
+use namespace Slack\GraphQL;
+
+/**
+ * Test GraphQL pagination
+ */
+final class PaginationTest extends PlaygroundTest {
+
+    <<__Override>>
+    public static function getTestCases(): this::TTestCases {
+        return dict[
+            'test retrieving edges after an index' => tuple(
+                'query ($after: String!) {
+                    human(id: 20) {
+                        friends(after: $after, first: 2) {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasNextPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict['after' => base64_encode("1")],
+                dict[
+                    'human' => dict[
+                        'friends' => dict[
+                            'edges' => vec[
+                                dict[
+                                    'node' => dict[
+                                        'id' => '2',
+                                        'name' => 'User 2',
+                                    ],
+                                    'cursor' => base64_encode('2'),
+                                ],
+                                dict[
+                                    'node' => dict[
+                                        'id' => '3',
+                                        'name' => 'User 3',
+                                    ],
+                                    'cursor' => base64_encode('3'),
+                                ],
+                            ],
+                            'pageInfo' => dict[
+                                'hasNextPage' => true,
+                                'startCursor' => base64_encode('2'),
+                                'endCursor' => base64_encode('3')
+                            ]
+                        ]
+                    ]
+                ]
+            ),
+
+            'test retrieving edges before an index' => tuple(
+                'query ($before: String!) {
+                    human(id: 20) {
+                        friends(before: $before, last: 2) {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasPreviousPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict['before' => base64_encode("4")],
+                dict[
+                    'human' => dict[
+                        'friends' => dict[
+                            'edges' => vec[
+                                dict[
+                                    'node' => dict[
+                                        'id' => '2',
+                                        'name' => 'User 2',
+                                    ],
+                                    'cursor' => base64_encode('2'),
+                                ],
+                                dict[
+                                    'node' => dict[
+                                        'id' => '3',
+                                        'name' => 'User 3',
+                                    ],
+                                    'cursor' => base64_encode('3'),
+                                ],
+                            ],
+                            'pageInfo' => dict[
+                                'hasPreviousPage' => true,
+                                'startCursor' => base64_encode('2'),
+                                'endCursor' => base64_encode('3')
+                            ]
+                        ]
+                    ]
+                ]
+            ),
+
+            'test providing first without after' => tuple(
+                'query {
+                    human(id: 20) {
+                        friends(first: 2) {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasNextPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    'human' => dict[
+                        'friends' => dict[
+                            'edges' => vec[
+                                dict[
+                                    'node' => dict[
+                                        'id' => '0',
+                                        'name' => 'User 0',
+                                    ],
+                                    'cursor' => base64_encode('0'),
+                                ],
+                                dict[
+                                    'node' => dict[
+                                        'id' => '1',
+                                        'name' => 'User 1',
+                                    ],
+                                    'cursor' => base64_encode('1'),
+                                ],
+                            ],
+                            'pageInfo' => dict[
+                                'hasNextPage' => true,
+                                'startCursor' => base64_encode('0'),
+                                'endCursor' => base64_encode('1')
+                            ]
+                        ]
+                    ]
+                ]
+            ),
+
+            'test providing last without before' => tuple(
+                'query {
+                    human(id: 20) {
+                        friends(last: 2) {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasPreviousPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    'human' => dict[
+                        'friends' => dict[
+                            'edges' => vec[
+                                dict[
+                                    'node' => dict[
+                                        'id' => '3',
+                                        'name' => 'User 3',
+                                    ],
+                                    'cursor' => base64_encode('3'),
+                                ],
+                                dict[
+                                    'node' => dict[
+                                        'id' => '4',
+                                        'name' => 'User 4',
+                                    ],
+                                    'cursor' => base64_encode('4'),
+                                ],
+                            ],
+                            'pageInfo' => dict[
+                                'hasPreviousPage' => true,
+                                'startCursor' => base64_encode('3'),
+                                'endCursor' => base64_encode('4')
+                            ]
+                        ]
+                    ]
+                ]
+            ),
+
+            'test providing both last and first' => tuple(
+                'query {
+                    human(id: 20) {
+                        friends(last: 5, first: 5) {
+                            edges {
+                                node {
+                                    id
+                                    name
+                                }
+                                cursor
+                            }
+                            pageInfo {
+                                hasPreviousPage
+                                startCursor
+                                endCursor
+                            }
+                        }
+                    }
+                }',
+                dict[],
+                shape(
+                    'data' => dict[
+                        'human' => dict[
+                            'friends' => null,
+                        ],
+                    ],
+                    'errors' => vec[
+                        shape(
+                            'message' => 'Only provide one of either "first" or "last".',
+                            'path' => vec['human', 'friends'],
+                        ),
+                    ],
+                )
+            )
+        ];
+    }
+}

--- a/tests/gen/Human.hack
+++ b/tests/gen/Human.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<44300e4bf463295c174cb50f838e36e6>>
+ * @generated SignedSource<<2302677adeae3af144120b3aca368f5c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -17,6 +17,7 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
   const type THackType = \Human;
   const keyset<string> FIELD_NAMES = keyset[
     'favorite_color',
+    'friends',
     'id',
     'is_active',
     'name',
@@ -36,6 +37,39 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
           FavoriteColor::nullableOutput(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getFavoriteColor(),
+        );
+      case 'friends':
+        return new GraphQL\FieldDefinition(
+          'friends',
+          UserConnection::nullableOutput(),
+          dict[
+            'after' => shape(
+              'name' => 'after',
+              'type' => Types\StringType::nullableInput(),
+              'default_value' => null,
+            ),
+            'before' => shape(
+              'name' => 'before',
+              'type' => Types\StringType::nullableInput(),
+              'default_value' => null,
+            ),
+            'first' => shape(
+              'name' => 'first',
+              'type' => Types\IntType::nullableInput(),
+              'default_value' => null,
+            ),
+            'last' => shape(
+              'name' => 'last',
+              'type' => Types\IntType::nullableInput(),
+              'default_value' => null,
+            ),
+          ],
+          async ($parent, $args, $vars) ==> (await $parent->getFriends())->setPaginationArgs(
+            Types\StringType::nullableInput()->coerceOptionalNamedNode('after', $args, $vars, null),
+            Types\StringType::nullableInput()->coerceOptionalNamedNode('before', $args, $vars, null),
+            Types\IntType::nullableInput()->coerceOptionalNamedNode('first', $args, $vars, null),
+            Types\IntType::nullableInput()->coerceOptionalNamedNode('last', $args, $vars, null),
+          ),
         );
       case 'id':
         return new GraphQL\FieldDefinition(

--- a/tests/gen/Human.hack
+++ b/tests/gen/Human.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<2302677adeae3af144120b3aca368f5c>>
+ * @generated SignedSource<<610ad67a380dfcc24d35298d39f1ba7a>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -21,6 +21,7 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
     'id',
     'is_active',
     'name',
+    'named_friends',
     'team',
   ];
   const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
@@ -91,6 +92,45 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
           Types\StringType::nullableOutput(),
           dict[],
           async ($parent, $args, $vars) ==> $parent->getName(),
+        );
+      case 'named_friends':
+        return new GraphQL\FieldDefinition(
+          'named_friends',
+          UserConnection::nullableOutput(),
+          dict[
+            'name_prefix' => shape(
+              'name' => 'name_prefix',
+              'type' => Types\StringType::nonNullable(),
+            ),
+            'after' => shape(
+              'name' => 'after',
+              'type' => Types\StringType::nullableInput(),
+              'default_value' => null,
+            ),
+            'before' => shape(
+              'name' => 'before',
+              'type' => Types\StringType::nullableInput(),
+              'default_value' => null,
+            ),
+            'first' => shape(
+              'name' => 'first',
+              'type' => Types\IntType::nullableInput(),
+              'default_value' => null,
+            ),
+            'last' => shape(
+              'name' => 'last',
+              'type' => Types\IntType::nullableInput(),
+              'default_value' => null,
+            ),
+          ],
+          async ($parent, $args, $vars) ==> (await $parent->getFriendsWithArg(
+            Types\StringType::nonNullable()->coerceNamedNode('name_prefix', $args, $vars),
+          ))->setPaginationArgs(
+            Types\StringType::nullableInput()->coerceOptionalNamedNode('after', $args, $vars, null),
+            Types\StringType::nullableInput()->coerceOptionalNamedNode('before', $args, $vars, null),
+            Types\IntType::nullableInput()->coerceOptionalNamedNode('first', $args, $vars, null),
+            Types\IntType::nullableInput()->coerceOptionalNamedNode('last', $args, $vars, null),
+          ),
         );
       case 'team':
         return new GraphQL\FieldDefinition(

--- a/tests/gen/PageInfo.hack
+++ b/tests/gen/PageInfo.hack
@@ -1,0 +1,63 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<cca639caaac8b03f1af47f96a942d215>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class PageInfo extends \Slack\GraphQL\Types\ObjectType {
+
+  const NAME = 'PageInfo';
+  const type THackType = \Slack\GraphQL\Pagination\PageInfo;
+  const keyset<string> FIELD_NAMES = keyset[
+    'startCursor',
+    'endCursor',
+    'hasPreviousPage',
+    'hasNextPage',
+  ];
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'startCursor':
+        return new GraphQL\FieldDefinition(
+          'startCursor',
+          Types\StringType::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent['startCursor'] ?? null,
+        );
+      case 'endCursor':
+        return new GraphQL\FieldDefinition(
+          'endCursor',
+          Types\StringType::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent['endCursor'] ?? null,
+        );
+      case 'hasPreviousPage':
+        return new GraphQL\FieldDefinition(
+          'hasPreviousPage',
+          Types\BooleanType::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent['hasPreviousPage'] ?? null,
+        );
+      case 'hasNextPage':
+        return new GraphQL\FieldDefinition(
+          'hasNextPage',
+          Types\BooleanType::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent['hasNextPage'] ?? null,
+        );
+      default:
+        return null;
+    }
+  }
+}

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<9e2664d1abcbb202090d5856437227d8>>
+ * @generated SignedSource<<20e304aa15825f3aa5ad6d39596ecf8e>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -38,10 +38,13 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
     'ObjectShape' => ObjectShape::class,
     'OutputShape' => OutputShape::class,
     'OutputTypeTestObj' => OutputTypeTestObj::class,
+    'PageInfo' => PageInfo::class,
     'Query' => Query::class,
     'String' => Types\StringType::class,
     'Team' => Team::class,
     'User' => User::class,
+    'UserConnection' => UserConnection::class,
+    'UserEdge' => UserEdge::class,
     '__EnumValue' => __EnumValue::class,
     '__Field' => __Field::class,
     '__InputValue' => __InputValue::class,

--- a/tests/gen/UserConnection.hack
+++ b/tests/gen/UserConnection.hack
@@ -1,0 +1,47 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<10f75bca86cba0f89742c4b2faf55f99>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class UserConnection extends \Slack\GraphQL\Types\ObjectType {
+
+  const NAME = 'UserConnection';
+  const type THackType = \UserConnection;
+  const keyset<string> FIELD_NAMES = keyset[
+    'edges',
+    'pageInfo',
+  ];
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'edges':
+        return new GraphQL\FieldDefinition(
+          'edges',
+          UserEdge::nonNullable()->nullableOutputListOf(),
+          dict[],
+          async ($parent, $args, $vars) ==> await $parent->getEdges(),
+        );
+      case 'pageInfo':
+        return new GraphQL\FieldDefinition(
+          'pageInfo',
+          PageInfo::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> await $parent->getPageInfo(),
+        );
+      default:
+        return null;
+    }
+  }
+}

--- a/tests/gen/UserEdge.hack
+++ b/tests/gen/UserEdge.hack
@@ -1,0 +1,47 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<10bd530f34fa766a0c89a1f81e8f8ad3>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class UserEdge extends \Slack\GraphQL\Types\ObjectType {
+
+  const NAME = 'UserEdge';
+  const type THackType = \Slack\GraphQL\Pagination\Edge<\User>;
+  const keyset<string> FIELD_NAMES = keyset[
+    'node',
+    'cursor',
+  ];
+  const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
+  ];
+
+  public function getFieldDefinition(
+    string $field_name,
+  ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
+    switch ($field_name) {
+      case 'node':
+        return new GraphQL\FieldDefinition(
+          'node',
+          User::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent->getNode(),
+        );
+      case 'cursor':
+        return new GraphQL\FieldDefinition(
+          'cursor',
+          Types\StringType::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent->getCursor(),
+        );
+      default:
+        return null;
+    }
+  }
+}


### PR DESCRIPTION
This is a pretty gnarly (IMO) first stab at pagination. You'll notice that I changed _a lot_ of things, especially when it comes to codegen. That's because connections and edges accept type parameters, which we've not handled yet during codegen. And to be honest, I wasn't sure _how_ to handle type parameters, so instead I just special-cased the connection and edge objects. What this means practically is that I've decoupled code generation from reflection. I _think_ this is a good thing. Basically, we no longer need reflection methods and classes to generate code — we can use them if we have them in hand, and we usually do, but for the case of generating classes which subclass classes with type arguments, or generating methods which return generics, it's better to just explicitly tell the code generator what we want to produce. As such:

* I created a new `FieldBuilder` base class which generates a GraphQL field from a spec.
* We still have MethodFieldBuilder and ShapeFieldBuilder. Before, these built GQL fields from Hack methods and Hack shape fields, respectively; now, they merely build GraphQL fields which resolve using Hack methods and Hack shape fields respectively. They can be built from any specification.
* We provide factory entrypoints for conveniently obtaining a MethodFieldBuilder or ShapeFieldBuilder from a Hack method or shape field. However, we don't _need_ to use these entrypoints — we can also tell the builders exactly what we want by calling their constructors directly. And this is what we do when generating connections and edges.
* I had to introduce a rather horrible special-cased `ConnectionFieldBuilder` which sets the pagination arguments on the connection immediately returned from calling the user-provided resolver. I'm not sure how else to do this short of making the user code accept the pagination arguments itself and pass them into the Connection constructor, which seems fine but also like the kind of thing the framework can automate.

I'm sort of conflicted about all these changes. On the one hand, they make it simpler to write user code, which we want. On the other hand, they introduce more complexity into codegen. I think separating out codegen from reflection is good and will create more flexibility down the line. I'm less sure about the special-cased handling of methods which return connections.

The reason for these changes, again, is that I just wasn't sure how else to handle codegen for connections. Since the user-defined connection subclass simply indicates by a type parameter what the edges returned from `getEdges` should be, the actual `getEdges` method has a generic return type. But we want to generate edge and connection types which are not generic, and I don't think we can use reflection to generate non-generic types from generic types. So I figured it was best to just tell the code generator exactly what we want for the special cases of connections and edges. Furthermore, I think connections and edges are the only objects in the GraphQL specification which require this special handling, so we won't need to do this all over the place 😓 .

I am, however, very open to alternative suggestions! I briefly explored using attributes like we do for introspection. This would make user code significantly more verbose (not just because of the additional attributes, but because we'd need to provide non-generic versions of all generic methods in each connection subclass). It might, however, eliminate most of the changes to codegen introduced by this PR. I figured the extra complexity in the framework is worth the enhanced developer experience, but could be persuaded otherwise.