### PR TITLE
Remaining introspection methods

### DIFF
--- a/src/Codegen/Builders/EnumBuilder.hack
+++ b/src/Codegen/Builders/EnumBuilder.hack
@@ -1,6 +1,7 @@
 namespace Slack\GraphQL\Codegen;
 
-use type Facebook\HackCodegen\{CodegenClass, HackBuilderValues, HackCodegenFactory};
+use namespace HH\Lib\Vec;
+use type Facebook\HackCodegen\{CodegenClass, HackBuilderValues, HackCodegenFactory, CodegenClassConstant};
 
 final class EnumBuilder extends TypeBuilder<\Slack\GraphQL\EnumType> implements ITypeBuilder {
     const classname<\Slack\GraphQL\Types\EnumType> SUPERCLASS = \Slack\GraphQL\Types\EnumType::class;
@@ -11,6 +12,28 @@ final class EnumBuilder extends TypeBuilder<\Slack\GraphQL\EnumType> implements 
                 $cg->codegenClassConstant('HACK_ENUM')
                     ->setType('\\HH\\enumname<this::THackType>')
                     ->setValue('\\'.$this->hack_type.'::class', HackBuilderValues::literal()),
+            )
+            ->addConstant($this->generateEnumValuesConstant($cg));
+    }
+
+    private function generateEnumValuesConstant(HackCodegenFactory $cg): CodegenClassConstant {
+        $rc = new \ReflectionClass($this->hack_type);
+        $values = vec[];
+
+        foreach ($rc->getConstants() as $name => $_) {
+            $values[] = shape(
+                'name' => $name,
+                // TODO: isDeprecated, description, deprecationReason
+                'isDeprecated' => false,
             );
+        }
+
+        $constant = $cg->codegenClassConstant('ENUM_VALUES')
+            ->setType('vec<GraphQL\Introspection\__EnumValue>')
+            ->setValue(
+                $values,
+                HackBuilderValues::vec(HackBuilderValues::shapeWithUniformRendering(HackBuilderValues::export())),
+            );
+        return $constant;
     }
 }

--- a/src/Codegen/Builders/InputObjectBuilder.hack
+++ b/src/Codegen/Builders/InputObjectBuilder.hack
@@ -91,7 +91,7 @@ class InputObjectBuilder extends InputTypeBuilder<\Slack\GraphQL\InputObjectType
             );
 
             $name_literal = \var_export($field_name, true);
-            $type = input_type(($is_optional ? '?' : '').type_structure_to_type_alias($field_ts));
+            $type = input_type(type_structure_to_type_alias($field_ts));
 
             if ($is_optional) {
                 $hb->startIfBlock($get_if_condition($name_literal));
@@ -124,8 +124,7 @@ class InputObjectBuilder extends InputTypeBuilder<\Slack\GraphQL\InputObjectType
             $hb->addLine('return shape(')->indent();
             $hb->addLinef("'name' => %s,", \var_export($field_name, true));
 
-            $is_optional = $field_ts['optional_shape_field'] ?? false;
-            $type = input_type(($is_optional ? '?' : '').type_structure_to_type_alias($field_ts));
+            $type = input_type(type_structure_to_type_alias($field_ts));
             $hb->addLinef("'type' => %s,", $type);
             // TODO: description, defaultValue
             $hb->unindent()->addLine(');')->unindent();

--- a/src/Introspection/__EnumValue.hack
+++ b/src/Introspection/__EnumValue.hack
@@ -3,17 +3,9 @@ namespace Slack\GraphQL\Introspection;
 use namespace Slack\GraphQL;
 
 <<GraphQL\ObjectType('__EnumValue', 'Enum value introspection')>>
-interface __EnumValue {
-
-    <<GraphQL\Field('name', 'Name of the enum value')>>
-    public function getName(): string;
-
-    <<GraphQL\Field('description', 'Description of the enum value')>>
-    public function getDescription(): ?string;
-
-    <<GraphQL\Field('isDeprecated', 'Boolean for whether or not the enum value is deprecated')>>
-    public function isDeprecated(): bool;
-
-    <<GraphQL\Field('deprecationReason', 'Reason the enum value was deprecated')>>
-    public function getDeprecationReason(): ?string;
-}
+type __EnumValue = shape(
+    'name' => string,
+    'isDeprecated' => bool,
+    ?'description' => string,
+    ?'deprecationReason' => string,
+);

--- a/src/Introspection/__InputValue.hack
+++ b/src/Introspection/__InputValue.hack
@@ -3,17 +3,9 @@ namespace Slack\GraphQL\Introspection;
 use namespace Slack\GraphQL;
 
 <<GraphQL\ObjectType('__InputValue', 'Input value introspection')>>
-interface __InputValue {
-
-    <<GraphQL\Field('name', 'Name of the field')>>
-    public function getName(): string;
-
-    <<GraphQL\Field('description', 'Description of the field')>>
-    public function getDescription(): ?string;
-
-    <<GraphQL\Field('type', 'Type of the field')>>
-    public function getType(): __Type;
-
-    <<GraphQL\Field('defaultValue', 'Default value the field')>>
-    public function getDefaultValue(): ?string;
-}
+type __InputValue = shape(
+    'name' => string,
+    ?'description' => ?string,
+    'type' => __Type,
+    ?'defaultValue' => ?string,
+);

--- a/src/Introspection/__Type.hack
+++ b/src/Introspection/__Type.hack
@@ -28,13 +28,11 @@ interface __Type {
     <<GraphQL\Field('possibleTypes', 'Possible types that implement this interface, only applies to INTERFACE')>>
     public function getIntrospectionPossibleTypes(): ?vec<__Type>;
 
-    // TODO: enumValues
     <<GraphQL\Field('enumValues', 'Enum values, only applies to ENUM')>>
     public function getIntrospectionEnumValues(bool $include_deprecated = false): ?vec<__EnumValue>;
 
-    // TODO: inputFields
     <<GraphQL\Field('inputFields', 'Input fields, only applies to INPUT_OBJECT')>>
-    public function getIntrospectionInputFields(bool $include_deprecated = false): ?vec<__InputValue>;
+    public function getIntrospectionInputFields(): ?vec<__InputValue>;
 
     <<GraphQL\Field('ofType', 'Underlying wrapped type, only applies to NON_NULL and LIST')>>
     public function getIntrospectionOfType(): ?__Type;

--- a/src/Types/Input/InputObjectType.hack
+++ b/src/Types/Input/InputObjectType.hack
@@ -1,6 +1,6 @@
 namespace Slack\GraphQL\Types;
 
-use namespace HH\Lib\C;
+use namespace HH\Lib\{C, Vec};
 use namespace Slack\GraphQL;
 use namespace Graphpinator\Parser\Value;
 
@@ -29,6 +29,7 @@ abstract class InputObjectType extends NamedType {
     }
 
     abstract protected function coerceFieldValues(KeyedContainer<arraykey, mixed> $values): this::THackType;
+    abstract protected function getInputValue(string $field_name): ?GraphQL\Introspection\__InputValue;
 
     <<__Override>>
     final protected function coerceNonVariableNode(
@@ -64,5 +65,10 @@ abstract class InputObjectType extends NamedType {
     <<__Override>>
     final public function getKind(): GraphQL\Introspection\__TypeKind {
         return GraphQL\Introspection\__TypeKind::INPUT_OBJECT;
+    }
+
+    <<__Override>>
+    final public function getInputFields(): vec<GraphQL\Introspection\__InputValue> {
+        return Vec\map(static::FIELD_NAMES, $field_name ==> $this->getInputValue($field_name) as nonnull);
     }
 }

--- a/src/Types/InputOutput/EnumType.hack
+++ b/src/Types/InputOutput/EnumType.hack
@@ -1,6 +1,6 @@
 namespace Slack\GraphQL\Types;
 
-use namespace HH\Lib\C;
+use namespace HH\Lib\{C, Vec};
 use namespace Graphpinator\Parser\Value;
 use namespace Slack\GraphQL;
 
@@ -9,6 +9,7 @@ abstract class EnumType extends LeafType {
     <<__Enforceable>>
     abstract const type THackType as arraykey;
     abstract const \HH\enumname<this::THackType> HACK_ENUM;
+    abstract const vec<GraphQL\Introspection\__EnumValue> ENUM_VALUES;
     const type TResolved = string;
 
     <<__Override>>
@@ -50,5 +51,12 @@ abstract class EnumType extends LeafType {
     final protected function serialize(this::THackType $value): string {
         $hack_enum = static::HACK_ENUM;
         return $hack_enum::getNames()[$value];
+    }
+
+    <<__Override>>
+    final public function getEnumValues(bool $include_deprecated = false): vec<GraphQL\Introspection\__EnumValue> {
+        return $include_deprecated
+            ? static::ENUM_VALUES
+            : Vec\filter(static::ENUM_VALUES, $value ==> !$value['isDeprecated']);
     }
 }

--- a/src/Types/NonNullableType.hack
+++ b/src/Types/NonNullableType.hack
@@ -11,7 +11,7 @@ interface INonNullableType {
     public function getInterfaces(): ?dict<string, classname<InterfaceType>>;
     public function getPossibleTypes(): ?vec<classname<ObjectType>>;
     public function getEnumValues(bool $include_deprecated = false): ?vec<Introspection\__EnumValue>;
-    public function getInputFields(bool $include_deprecated = false): ?vec<Introspection\__InputValue>;
+    public function getInputFields(): ?vec<Introspection\__InputValue>;
     public function getOfType(): ?Introspection\__Type;
     public function nullableForIntrospection(): INullableType;
 }
@@ -99,7 +99,7 @@ trait TNonNullableType implements INonNullableType {
         return null;
     }
 
-    public function getInputFields(bool $include_deprecated = false): ?vec<Introspection\__InputValue> {
+    public function getInputFields(): ?vec<Introspection\__InputValue> {
         return null;
     }
 

--- a/src/playground/IntrospectionTestObjects.hack
+++ b/src/playground/IntrospectionTestObjects.hack
@@ -1,5 +1,11 @@
 use namespace Slack\GraphQL;
 
+<<GraphQL\EnumType('IntrospectionEnum', 'IntrospectionEnum')>>
+enum IntrospectionEnum: int {
+    A = 0;
+    B = 1;
+}
+
 <<GraphQL\InterfaceType('IIntrospectionInterfaceA', 'IIntrospectionInterfaceA')>>
 interface IIntrospectionInterfaceA {}
 

--- a/src/playground/IntrospectionTestObjects.hack
+++ b/src/playground/IntrospectionTestObjects.hack
@@ -1,5 +1,20 @@
 use namespace Slack\GraphQL;
 
+<<GraphQL\InputObjectType('IntrospectionRootInput', '')>>
+type TRootInput = shape(
+    ?'scalar' => ?string,
+    ?'nested' => ?TNestedInput,
+    ?'vec_of_nested_non_nullable' => ?vec<TNestedInput>,
+    ?'vec_of_nested_nullable' => ?vec<?TNestedInput>,
+    'non_nullable' => string,
+);
+
+<<GraphQL\InputObjectType('IntrospectionNestedInput', '')>>
+type TNestedInput = shape(
+    'string' => string,
+    'vec_of_string' => vec<string>,
+);
+
 <<GraphQL\EnumType('IntrospectionEnum', 'IntrospectionEnum')>>
 enum IntrospectionEnum: int {
     A = 0;

--- a/tests/IntrospectionTest.hack
+++ b/tests/IntrospectionTest.hack
@@ -8,6 +8,89 @@ final class IntrospectionTest extends PlaygroundTest {
     <<__Override>>
     public static function getTestCases(): this::TTestCases {
         return dict[
+            'validate input fields' => tuple(
+                '{
+                    __type(name: "IntrospectionRootInput") {
+                        inputFields {
+                            name
+                            type {
+                                kind
+                                name
+                                ofType {
+                                    kind
+                                    name
+                                    ofType {
+                                        kind
+                                        name
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }',
+                dict[],
+                dict[
+                    '__type' => dict[
+                        'inputFields' => vec[
+                            dict[
+                                'name' => 'scalar',
+                                'type' => dict[
+                                    'kind' => 'SCALAR',
+                                    'name' => 'String',
+                                    'ofType' => null,
+                                ],
+                            ],
+                            dict[
+                                'name' => 'nested',
+                                'type' => dict[
+                                    'kind' => 'INPUT_OBJECT',
+                                    'name' => 'IntrospectionNestedInput',
+                                    'ofType' => null,
+                                ],
+                            ],
+                            dict[
+                                'name' => 'vec_of_nested_non_nullable',
+                                'type' => dict[
+                                    'kind' => 'LIST',
+                                    'name' => null,
+                                    'ofType' => dict[
+                                        'kind' => 'NON_NULL',
+                                        'name' => null,
+                                        'ofType' => dict[
+                                            'kind' => 'INPUT_OBJECT',
+                                            'name' => 'IntrospectionNestedInput',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            dict[
+                                'name' => 'vec_of_nested_nullable',
+                                'type' => dict[
+                                    'kind' => 'LIST',
+                                    'name' => null,
+                                    'ofType' => dict[
+                                        'kind' => 'INPUT_OBJECT',
+                                        'name' => 'IntrospectionNestedInput',
+                                        'ofType' => null,
+                                    ],
+                                ],
+                            ],
+                            dict[
+                                'name' => 'non_nullable',
+                                'type' => dict[
+                                    'kind' => 'NON_NULL',
+                                    'name' => null,
+                                    'ofType' => dict[
+                                        'kind' => 'SCALAR',
+                                        'name' => 'String',
+                                        'ofType' => null,
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ),
             'validate enum values' => tuple(
                 '{
                     __type(name: "IntrospectionEnum") {

--- a/tests/IntrospectionTest.hack
+++ b/tests/IntrospectionTest.hack
@@ -8,6 +8,37 @@ final class IntrospectionTest extends PlaygroundTest {
     <<__Override>>
     public static function getTestCases(): this::TTestCases {
         return dict[
+            'validate enum values' => tuple(
+                '{
+                    __type(name: "IntrospectionEnum") {
+                        enumValues {
+                            name
+                            description
+                            isDeprecated
+                            deprecationReason
+                        }
+                    }
+                 }',
+                dict[],
+                dict[
+                    '__type' => dict[
+                        'enumValues' => vec[
+                            dict[
+                                'name' => 'A',
+                                'description' => null,
+                                'isDeprecated' => false,
+                                'deprecationReason' => null,
+                            ],
+                            dict[
+                                'name' => 'B',
+                                'description' => null,
+                                'isDeprecated' => false,
+                                'deprecationReason' => null,
+                            ],
+                        ],
+                    ],
+                ],
+            ),
             'validate interface introspection with extended interface' => tuple(
                 '{
                     __type(name: "IIntrospectionInterfaceA") {

--- a/tests/gen/CreateTeamInput.hack
+++ b/tests/gen/CreateTeamInput.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<1c07104ec609d81e4a59e21194b769ff>>
+ * @generated SignedSource<<312b5197df4461595cab71ab449fbb0d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -45,5 +45,20 @@ final class CreateTeamInput extends \Slack\GraphQL\Types\InputObjectType {
     $ret = shape();
     $ret['name'] = Types\StringType::nonNullable()->assertValidVariableValue($fields['name']);
     return $ret;
+  }
+
+  <<__Override>>
+  protected function getInputValue(
+    string $field_name,
+  ): ?GraphQL\Introspection\__InputValue {
+    switch ($field_name) {
+      case 'name':
+        return shape(
+          'name' => 'name',
+          'type' => Types\StringType::nonNullable(),
+        );
+      default:
+        return null;
+    }
   }
 }

--- a/tests/gen/CreateUserInput.hack
+++ b/tests/gen/CreateUserInput.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<23f15b4f21de51255c993f0a0c93c3b1>>
+ * @generated SignedSource<<ce0dce14e824f4421ff9f5e4d9ff60a5>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -75,5 +75,35 @@ final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
       $ret['favorite_color'] = FavoriteColor::nullableInput()->assertValidVariableValue($fields['favorite_color']);
     }
     return $ret;
+  }
+
+  <<__Override>>
+  protected function getInputValue(
+    string $field_name,
+  ): ?GraphQL\Introspection\__InputValue {
+    switch ($field_name) {
+      case 'name':
+        return shape(
+          'name' => 'name',
+          'type' => Types\StringType::nonNullable(),
+        );
+      case 'is_active':
+        return shape(
+          'name' => 'is_active',
+          'type' => Types\BooleanType::nullableInput(),
+        );
+      case 'team':
+        return shape(
+          'name' => 'team',
+          'type' => CreateTeamInput::nullableInput(),
+        );
+      case 'favorite_color':
+        return shape(
+          'name' => 'favorite_color',
+          'type' => FavoriteColor::nullableInput(),
+        );
+      default:
+        return null;
+    }
   }
 }

--- a/tests/gen/IntrospectionEnum.hack
+++ b/tests/gen/IntrospectionEnum.hack
@@ -4,25 +4,25 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d0d41c32f3eef2f3de0ccd4ce8efed53>>
+ * @generated SignedSource<<c433c1cc0fb72874364dc2473249cc5d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
 use namespace HH\Lib\{C, Dict};
 
-final class FavoriteColor extends \Slack\GraphQL\Types\EnumType {
+final class IntrospectionEnum extends \Slack\GraphQL\Types\EnumType {
 
-  const NAME = 'FavoriteColor';
-  const type THackType = \FavoriteColor;
-  const \HH\enumname<this::THackType> HACK_ENUM = \FavoriteColor::class;
+  const NAME = 'IntrospectionEnum';
+  const type THackType = \IntrospectionEnum;
+  const \HH\enumname<this::THackType> HACK_ENUM = \IntrospectionEnum::class;
   const vec<GraphQL\Introspection\__EnumValue> ENUM_VALUES = vec[
     shape(
-      'name' => 'RED',
+      'name' => 'A',
       'isDeprecated' => false,
     ),
     shape(
-      'name' => 'BLUE',
+      'name' => 'B',
       'isDeprecated' => false,
     ),
   ];

--- a/tests/gen/IntrospectionNestedInput.hack
+++ b/tests/gen/IntrospectionNestedInput.hack
@@ -1,0 +1,74 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<c00cfa1740b3cf8339262d169497bf1e>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class IntrospectionNestedInput
+  extends \Slack\GraphQL\Types\InputObjectType {
+
+  const NAME = 'IntrospectionNestedInput';
+  const type THackType = \TNestedInput;
+  const keyset<string> FIELD_NAMES = keyset [
+    'string',
+    'vec_of_string',
+  ];
+
+  <<__Override>>
+  public function coerceFieldValues(
+    KeyedContainer<arraykey, mixed> $fields,
+  ): this::THackType {
+    $ret = shape();
+    $ret['string'] = Types\StringType::nonNullable()->coerceNamedValue('string', $fields);
+    $ret['vec_of_string'] = Types\StringType::nonNullable()->nonNullableInputListOf()->coerceNamedValue('vec_of_string', $fields);
+    return $ret;
+  }
+
+  <<__Override>>
+  public function coerceFieldNodes(
+    dict<string, \Graphpinator\Parser\Value\Value> $fields,
+    dict<string, mixed> $vars,
+  ): this::THackType {
+    $ret = shape();
+    $ret['string'] = Types\StringType::nonNullable()->coerceNamedNode('string', $fields, $vars);
+    $ret['vec_of_string'] = Types\StringType::nonNullable()->nonNullableInputListOf()->coerceNamedNode('vec_of_string', $fields, $vars);
+    return $ret;
+  }
+
+  <<__Override>>
+  public function assertValidFieldValues(
+    KeyedContainer<arraykey, mixed> $fields,
+  ): this::THackType {
+    $ret = shape();
+    $ret['string'] = Types\StringType::nonNullable()->assertValidVariableValue($fields['string']);
+    $ret['vec_of_string'] = Types\StringType::nonNullable()->nonNullableInputListOf()->assertValidVariableValue($fields['vec_of_string']);
+    return $ret;
+  }
+
+  <<__Override>>
+  protected function getInputValue(
+    string $field_name,
+  ): ?GraphQL\Introspection\__InputValue {
+    switch ($field_name) {
+      case 'string':
+        return shape(
+          'name' => 'string',
+          'type' => Types\StringType::nonNullable(),
+        );
+      case 'vec_of_string':
+        return shape(
+          'name' => 'vec_of_string',
+          'type' => Types\StringType::nonNullable()->nonNullableInputListOf(),
+        );
+      default:
+        return null;
+    }
+  }
+}

--- a/tests/gen/IntrospectionRootInput.hack
+++ b/tests/gen/IntrospectionRootInput.hack
@@ -1,0 +1,125 @@
+/**
+ * This file is generated. Do not modify it manually!
+ *
+ * To re-generate this file run vendor/bin/hacktest
+ *
+ *
+ * @generated SignedSource<<24d6228313f9d2588f4243d7235b3b54>>
+ */
+namespace Slack\GraphQL\Test\Generated;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Types;
+use namespace HH\Lib\{C, Dict};
+
+final class IntrospectionRootInput
+  extends \Slack\GraphQL\Types\InputObjectType {
+
+  const NAME = 'IntrospectionRootInput';
+  const type THackType = \TRootInput;
+  const keyset<string> FIELD_NAMES = keyset [
+    'scalar',
+    'nested',
+    'vec_of_nested_non_nullable',
+    'vec_of_nested_nullable',
+    'non_nullable',
+  ];
+
+  <<__Override>>
+  public function coerceFieldValues(
+    KeyedContainer<arraykey, mixed> $fields,
+  ): this::THackType {
+    $ret = shape();
+    if (C\contains_key($fields, 'scalar')) {
+      $ret['scalar'] = Types\StringType::nullableInput()->coerceNamedValue('scalar', $fields);
+    }
+    if (C\contains_key($fields, 'nested')) {
+      $ret['nested'] = IntrospectionNestedInput::nullableInput()->coerceNamedValue('nested', $fields);
+    }
+    if (C\contains_key($fields, 'vec_of_nested_non_nullable')) {
+      $ret['vec_of_nested_non_nullable'] = IntrospectionNestedInput::nonNullable()->nullableInputListOf()->coerceNamedValue('vec_of_nested_non_nullable', $fields);
+    }
+    if (C\contains_key($fields, 'vec_of_nested_nullable')) {
+      $ret['vec_of_nested_nullable'] = IntrospectionNestedInput::nullableInput()->nullableInputListOf()->coerceNamedValue('vec_of_nested_nullable', $fields);
+    }
+    $ret['non_nullable'] = Types\StringType::nonNullable()->coerceNamedValue('non_nullable', $fields);
+    return $ret;
+  }
+
+  <<__Override>>
+  public function coerceFieldNodes(
+    dict<string, \Graphpinator\Parser\Value\Value> $fields,
+    dict<string, mixed> $vars,
+  ): this::THackType {
+    $ret = shape();
+    if ($this->hasValue('scalar', $fields, $vars)) {
+      $ret['scalar'] = Types\StringType::nullableInput()->coerceNamedNode('scalar', $fields, $vars);
+    }
+    if ($this->hasValue('nested', $fields, $vars)) {
+      $ret['nested'] = IntrospectionNestedInput::nullableInput()->coerceNamedNode('nested', $fields, $vars);
+    }
+    if ($this->hasValue('vec_of_nested_non_nullable', $fields, $vars)) {
+      $ret['vec_of_nested_non_nullable'] = IntrospectionNestedInput::nonNullable()->nullableInputListOf()->coerceNamedNode('vec_of_nested_non_nullable', $fields, $vars);
+    }
+    if ($this->hasValue('vec_of_nested_nullable', $fields, $vars)) {
+      $ret['vec_of_nested_nullable'] = IntrospectionNestedInput::nullableInput()->nullableInputListOf()->coerceNamedNode('vec_of_nested_nullable', $fields, $vars);
+    }
+    $ret['non_nullable'] = Types\StringType::nonNullable()->coerceNamedNode('non_nullable', $fields, $vars);
+    return $ret;
+  }
+
+  <<__Override>>
+  public function assertValidFieldValues(
+    KeyedContainer<arraykey, mixed> $fields,
+  ): this::THackType {
+    $ret = shape();
+    if (C\contains_key($fields, 'scalar')) {
+      $ret['scalar'] = Types\StringType::nullableInput()->assertValidVariableValue($fields['scalar']);
+    }
+    if (C\contains_key($fields, 'nested')) {
+      $ret['nested'] = IntrospectionNestedInput::nullableInput()->assertValidVariableValue($fields['nested']);
+    }
+    if (C\contains_key($fields, 'vec_of_nested_non_nullable')) {
+      $ret['vec_of_nested_non_nullable'] = IntrospectionNestedInput::nonNullable()->nullableInputListOf()->assertValidVariableValue($fields['vec_of_nested_non_nullable']);
+    }
+    if (C\contains_key($fields, 'vec_of_nested_nullable')) {
+      $ret['vec_of_nested_nullable'] = IntrospectionNestedInput::nullableInput()->nullableInputListOf()->assertValidVariableValue($fields['vec_of_nested_nullable']);
+    }
+    $ret['non_nullable'] = Types\StringType::nonNullable()->assertValidVariableValue($fields['non_nullable']);
+    return $ret;
+  }
+
+  <<__Override>>
+  protected function getInputValue(
+    string $field_name,
+  ): ?GraphQL\Introspection\__InputValue {
+    switch ($field_name) {
+      case 'scalar':
+        return shape(
+          'name' => 'scalar',
+          'type' => Types\StringType::nullableInput(),
+        );
+      case 'nested':
+        return shape(
+          'name' => 'nested',
+          'type' => IntrospectionNestedInput::nullableInput(),
+        );
+      case 'vec_of_nested_non_nullable':
+        return shape(
+          'name' => 'vec_of_nested_non_nullable',
+          'type' => IntrospectionNestedInput::nonNullable()->nullableInputListOf(),
+        );
+      case 'vec_of_nested_nullable':
+        return shape(
+          'name' => 'vec_of_nested_nullable',
+          'type' => IntrospectionNestedInput::nullableInput()->nullableInputListOf(),
+        );
+      case 'non_nullable':
+        return shape(
+          'name' => 'non_nullable',
+          'type' => Types\StringType::nonNullable(),
+        );
+      default:
+        return null;
+    }
+  }
+}

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<05cd729532a7ff7c84a04aff87401a1f>>
+ * @generated SignedSource<<161ebed94c514c60876a1f2547f0f58d>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -33,6 +33,9 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
     'Int' => Types\IntType::class,
     'InterfaceA' => InterfaceA::class,
     'InterfaceB' => InterfaceB::class,
+    'IntrospectionEnum' => IntrospectionEnum::class,
+    'IntrospectionNestedInput' => IntrospectionNestedInput::class,
+    'IntrospectionRootInput' => IntrospectionRootInput::class,
     'IntrospectionTestObject' => IntrospectionTestObject::class,
     'Mutation' => Mutation::class,
     'NestedOutputShape' => NestedOutputShape::class,

--- a/tests/gen/__EnumValue.hack
+++ b/tests/gen/__EnumValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<f121838086bb0d72ad9cbc92b7497eed>>
+ * @generated SignedSource<<2a376d1323cd8b83e6af8c63aa02034c>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -16,10 +16,10 @@ final class __EnumValue extends \Slack\GraphQL\Types\ObjectType {
   const NAME = '__EnumValue';
   const type THackType = \Slack\GraphQL\Introspection\__EnumValue;
   const keyset<string> FIELD_NAMES = keyset[
-    'deprecationReason',
-    'description',
-    'isDeprecated',
     'name',
+    'isDeprecated',
+    'description',
+    'deprecationReason',
   ];
   const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
@@ -28,33 +28,33 @@ final class __EnumValue extends \Slack\GraphQL\Types\ObjectType {
     string $field_name,
   ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
     switch ($field_name) {
-      case 'deprecationReason':
+      case 'name':
         return new GraphQL\FieldDefinition(
-          'deprecationReason',
+          'name',
           Types\StringType::nullableOutput(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->getDeprecationReason(),
-        );
-      case 'description':
-        return new GraphQL\FieldDefinition(
-          'description',
-          Types\StringType::nullableOutput(),
-          dict[],
-          async ($parent, $args, $vars) ==> $parent->getDescription(),
+          async ($parent, $args, $vars) ==> $parent['name'],
         );
       case 'isDeprecated':
         return new GraphQL\FieldDefinition(
           'isDeprecated',
           Types\BooleanType::nullableOutput(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->isDeprecated(),
+          async ($parent, $args, $vars) ==> $parent['isDeprecated'],
         );
-      case 'name':
+      case 'description':
         return new GraphQL\FieldDefinition(
-          'name',
+          'description',
           Types\StringType::nullableOutput(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->getName(),
+          async ($parent, $args, $vars) ==> $parent['description'] ?? null,
+        );
+      case 'deprecationReason':
+        return new GraphQL\FieldDefinition(
+          'deprecationReason',
+          Types\StringType::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent['deprecationReason'] ?? null,
         );
       default:
         return null;

--- a/tests/gen/__InputValue.hack
+++ b/tests/gen/__InputValue.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d4a8b8d680bf78c9c3646e48c703e7dc>>
+ * @generated SignedSource<<e91079c818844bd61c1aeffb29962598>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -16,10 +16,10 @@ final class __InputValue extends \Slack\GraphQL\Types\ObjectType {
   const NAME = '__InputValue';
   const type THackType = \Slack\GraphQL\Introspection\__InputValue;
   const keyset<string> FIELD_NAMES = keyset[
-    'defaultValue',
-    'description',
     'name',
+    'description',
     'type',
+    'defaultValue',
   ];
   const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
   ];
@@ -28,33 +28,33 @@ final class __InputValue extends \Slack\GraphQL\Types\ObjectType {
     string $field_name,
   ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
     switch ($field_name) {
-      case 'defaultValue':
+      case 'name':
         return new GraphQL\FieldDefinition(
-          'defaultValue',
+          'name',
           Types\StringType::nullableOutput(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->getDefaultValue(),
+          async ($parent, $args, $vars) ==> $parent['name'],
         );
       case 'description':
         return new GraphQL\FieldDefinition(
           'description',
           Types\StringType::nullableOutput(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->getDescription(),
-        );
-      case 'name':
-        return new GraphQL\FieldDefinition(
-          'name',
-          Types\StringType::nullableOutput(),
-          dict[],
-          async ($parent, $args, $vars) ==> $parent->getName(),
+          async ($parent, $args, $vars) ==> $parent['description'] ?? null,
         );
       case 'type':
         return new GraphQL\FieldDefinition(
           'type',
           __Type::nullableOutput(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->getType(),
+          async ($parent, $args, $vars) ==> $parent['type'],
+        );
+      case 'defaultValue':
+        return new GraphQL\FieldDefinition(
+          'defaultValue',
+          Types\StringType::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent['defaultValue'] ?? null,
         );
       default:
         return null;

--- a/tests/gen/__Type.hack
+++ b/tests/gen/__Type.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<09209020c33d8df06c4c39667cbcdbef>>
+ * @generated SignedSource<<2bf4232b2861d42a846170b0e37107fb>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -74,16 +74,8 @@ final class __Type extends \Slack\GraphQL\Types\ObjectType {
         return new GraphQL\FieldDefinition(
           'inputFields',
           __InputValue::nonNullable()->nullableOutputListOf(),
-          dict[
-            'include_deprecated' => shape(
-              'name' => 'include_deprecated',
-              'type' => Types\BooleanType::nonNullable(),
-              'default_value' => false,
-            ),
-          ],
-          async ($parent, $args, $vars) ==> $parent->getIntrospectionInputFields(
-            Types\BooleanType::nonNullable()->coerceOptionalNamedNode('include_deprecated', $args, $vars, false),
-          ),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent->getIntrospectionInputFields(),
         );
       case 'interfaces':
         return new GraphQL\FieldDefinition(

--- a/tests/gen/__TypeKind.hack
+++ b/tests/gen/__TypeKind.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<b98befaa350193017a33d5dcbd92b03e>>
+ * @generated SignedSource<<edf84a7e9478dd5e94045aeee8de6cc7>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -16,4 +16,38 @@ final class __TypeKind extends \Slack\GraphQL\Types\EnumType {
   const NAME = '__TypeKind';
   const type THackType = \Slack\GraphQL\Introspection\__TypeKind;
   const \HH\enumname<this::THackType> HACK_ENUM = \Slack\GraphQL\Introspection\__TypeKind::class;
+  const vec<GraphQL\Introspection\__EnumValue> ENUM_VALUES = vec[
+    shape(
+      'name' => 'SCALAR',
+      'isDeprecated' => false,
+    ),
+    shape(
+      'name' => 'OBJECT',
+      'isDeprecated' => false,
+    ),
+    shape(
+      'name' => 'INTERFACE',
+      'isDeprecated' => false,
+    ),
+    shape(
+      'name' => 'UNION',
+      'isDeprecated' => false,
+    ),
+    shape(
+      'name' => 'ENUM',
+      'isDeprecated' => false,
+    ),
+    shape(
+      'name' => 'INPUT_OBJECT',
+      'isDeprecated' => false,
+    ),
+    shape(
+      'name' => 'LIST',
+      'isDeprecated' => false,
+    ),
+    shape(
+      'name' => 'NON_NULL',
+      'isDeprecated' => false,
+    ),
+  ];
 }


### PR DESCRIPTION
This implements `enumValues` and `inputFields` which were the two big remaining introspection pieces remaining. There are still some TODOs scattered to support description, default value, etc.

I broke this up into two commits, first for enum values and next for input fields.

For input objects, we currently have a bug where you can't use a value with a generic parameter, ie this doesn't work: 

```
<<GraphQL\InputObjectType('IntrospectionRootInput', '')>>
type TRootInput = shape(
    'scalar' => string,
    'nested' => TNestedInput,
    'vec_of_nested' => vec<TNestedInput>,
);

<<GraphQL\InputObjectType('IntrospectionNestedInput', '')>>
type TNestedInput = shape(
    'string' => string,
    'vec_of_string' => vec<string>,
);
```

Because `THackType` is marked as `__Enforceable` so we can't use it with generics that are erased at runtime (ie `vec<TNestedInput>` and `vec<string>`. 

I was reading through this: https://docs.hhvm.com/hack/reified-generics/reified-generics to see if we could use reified generics but didn't see how to apply those to class constants.