### PR TITLE
fix InputObjectType::assertValidVariableValues

### DIFF
--- a/src/Types/Input/InputObjectType.hack
+++ b/src/Types/Input/InputObjectType.hack
@@ -9,7 +9,6 @@ abstract class InputObjectType extends NamedType {
     use TNonNullableType;
     use TNamedInputType;
 
-    <<__Enforceable>>
     abstract const type THackType as shape(...);
     abstract const keyset<string> FIELD_NAMES;
 
@@ -54,6 +53,13 @@ abstract class InputObjectType extends NamedType {
         dict<string, Value\Value> $value_nodes,
         dict<string, mixed> $variable_values,
     ): this::THackType;
+
+    <<__Override>>
+    final public function assertValidVariableValue(mixed $value): this::THackType {
+        return $this->assertValidFieldValues($value as KeyedContainer<_, _>);
+    }
+
+    abstract protected function assertValidFieldValues(KeyedContainer<arraykey, mixed> $values): this::THackType;
 
     <<__Override>>
     final public function getKind(): GraphQL\Introspection\__TypeKind {

--- a/src/Types/Input/NamedInputType.hack
+++ b/src/Types/Input/NamedInputType.hack
@@ -11,20 +11,12 @@ namespace Slack\GraphQL\Types;
 interface INamedInputType extends INonNullableInputTypeFor<this::THackType> {
     require extends NamedType;
 
-    <<__Enforceable>>
-    abstract const type THackType as nonnull;
-
     public static function nullableInput(): NullableInputType<this::THackType>;
 }
 
 <<__ConsistentConstruct>>
 trait TNamedInputType implements INamedInputType {
     use TInputType<this::THackType>;
-
-    <<__Override>>
-    final public function assertValidVariableValue(mixed $value): this::THackType {
-        return $value as this::THackType;
-    }
 
     <<__Override, __MemoizeLSB>>
     final public static function nullableInput(): NullableInputType<this::THackType> {

--- a/src/Types/InputOutput/LeafType.hack
+++ b/src/Types/InputOutput/LeafType.hack
@@ -7,6 +7,14 @@ abstract class LeafType extends NamedType {
     use TNamedInputType;
     use TNamedOutputType;
 
+    <<__Enforceable>>
+    abstract const type THackType as nonnull;
+
+    <<__Override>>
+    final public function assertValidVariableValue(mixed $value): this::THackType {
+        return $value as this::THackType;
+    }
+
     /**
      * Convert a Hack value to what should be returned in the GraphQL response. Throw UserFacingError if that is not
      * possible (e.g. Int out of 32-bit range).

--- a/tests/gen/CreateTeamInput.hack
+++ b/tests/gen/CreateTeamInput.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<75a0b6a31b2d57480f9f9847bac621c5>>
+ * @generated SignedSource<<1c07104ec609d81e4a59e21194b769ff>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -35,6 +35,15 @@ final class CreateTeamInput extends \Slack\GraphQL\Types\InputObjectType {
   ): this::THackType {
     $ret = shape();
     $ret['name'] = Types\StringType::nonNullable()->coerceNamedNode('name', $fields, $vars);
+    return $ret;
+  }
+
+  <<__Override>>
+  public function assertValidFieldValues(
+    KeyedContainer<arraykey, mixed> $fields,
+  ): this::THackType {
+    $ret = shape();
+    $ret['name'] = Types\StringType::nonNullable()->assertValidVariableValue($fields['name']);
     return $ret;
   }
 }

--- a/tests/gen/CreateUserInput.hack
+++ b/tests/gen/CreateUserInput.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<d1da705de7b13fa3ac9c4c978215d91a>>
+ * @generated SignedSource<<23f15b4f21de51255c993f0a0c93c3b1>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -55,6 +55,24 @@ final class CreateUserInput extends \Slack\GraphQL\Types\InputObjectType {
     }
     if ($this->hasValue('favorite_color', $fields, $vars)) {
       $ret['favorite_color'] = FavoriteColor::nullableInput()->coerceNamedNode('favorite_color', $fields, $vars);
+    }
+    return $ret;
+  }
+
+  <<__Override>>
+  public function assertValidFieldValues(
+    KeyedContainer<arraykey, mixed> $fields,
+  ): this::THackType {
+    $ret = shape();
+    $ret['name'] = Types\StringType::nonNullable()->assertValidVariableValue($fields['name']);
+    if (C\contains_key($fields, 'is_active')) {
+      $ret['is_active'] = Types\BooleanType::nullableInput()->assertValidVariableValue($fields['is_active']);
+    }
+    if (C\contains_key($fields, 'team')) {
+      $ret['team'] = CreateTeamInput::nullableInput()->assertValidVariableValue($fields['team']);
+    }
+    if (C\contains_key($fields, 'favorite_color')) {
+      $ret['favorite_color'] = FavoriteColor::nullableInput()->assertValidVariableValue($fields['favorite_color']);
     }
     return $ret;
   }


### PR DESCRIPTION
Needs proper implementation, since they can have list fields which aren't `<<__Enforceable>>`.

I updated the codegen code to minimize duplicate logic, since the generated class now has 3 similar methods.