### PR TITLE
Promises

### DIFF
--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -13,7 +13,7 @@ abstract class BaseSchema implements Introspection\__Schema {
     abstract public static function resolveQuery(
         \Graphpinator\Parser\Operation\Operation $operation,
         ExecutionContext $context,
-    ): Awaitable<ValidFieldResult<?dict<string, mixed>>>;
+    ): Awaitable<FieldResult<?dict<string, mixed>>>;
 
     /**
     * Mutations are optional, if the schema supports it, this method will be
@@ -22,7 +22,7 @@ abstract class BaseSchema implements Introspection\__Schema {
     public static async function resolveMutation(
         \Graphpinator\Parser\Operation\Operation $operation,
         ExecutionContext $context,
-    ): Awaitable<ValidFieldResult<?dict<string, mixed>>> {
+    ): Awaitable<FieldResult<?dict<string, mixed>>> {
         return new ValidFieldResult(null);
     }
 

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -182,7 +182,7 @@ final class Generator {
             ->setPublic()
             ->setIsStatic(true)
             ->setIsAsync(true)
-            ->setReturnType('Awaitable<GraphQL\\ValidFieldResult<?dict<string, mixed>>>')
+            ->setReturnType('Awaitable<GraphQL\\FieldResult<?dict<string, mixed>>>')
             ->addParameterf('\%s $operation', \Graphpinator\Parser\Operation\Operation::class)
             ->addParameterf('\%s $context', \Slack\GraphQL\ExecutionContext::class);
 

--- a/src/ExecutionContext.hack
+++ b/src/ExecutionContext.hack
@@ -6,6 +6,7 @@ use namespace Slack\GraphQL;
 use type Graphpinator\Parser\Fragment\Fragment;
 
 final class ExecutionContext {
+
     public function __construct(
         private dict<string, mixed> $coercedVariableValues,
         private dict<string, Fragment> $fragmentDeclarations,

--- a/src/ExecutionContext.hack
+++ b/src/ExecutionContext.hack
@@ -6,7 +6,6 @@ use namespace Slack\GraphQL;
 use type Graphpinator\Parser\Fragment\Fragment;
 
 final class ExecutionContext {
-
     public function __construct(
         private dict<string, mixed> $coercedVariableValues,
         private dict<string, Fragment> $fragmentDeclarations,

--- a/src/FieldResult.hack
+++ b/src/FieldResult.hack
@@ -10,14 +10,6 @@ abstract class FieldResult<+T> {
     final public function getErrors(): vec<UserFacingError> {
         return $this->errors;
     }
-
-    public async function resolveAsync(): Awaitable<FieldResult<T>> {
-        return $this;
-    }
-
-    public function isDeferred(): bool {
-        return $this is DeferredFieldResult<_>;
-    }
 }
 
 final class DeferredFieldResult<+T> extends FieldResult<T> {
@@ -44,7 +36,6 @@ final class DeferredFieldResult<+T> extends FieldResult<T> {
  * - null value with error, if this is a nullable field that failed to resolve
  */
 final class ValidFieldResult<+T> extends FieldResult<T> {
-
     public function __construct(
         private T $value,
         vec<UserFacingError> $errors = vec[],

--- a/src/Promise.hack
+++ b/src/Promise.hack
@@ -1,0 +1,10 @@
+namespace Slack\GraphQL;
+
+final class Promise<+T> {
+    public function __construct(private (function (): Awaitable<T>) $cb) {}
+
+    public async function resolve(): Awaitable<T> {
+        $cb = $this->cb;
+        return await $cb();
+    }
+}

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -113,7 +113,7 @@ final class Resolver {
                 throw new \Error('Unsupported operation: '.$operation_type);
         }
 
-        while ($result->isDeferred()) {
+        while ($result is DeferredFieldResult<_>) {
             // This is where we'd batch load data for all pending promises
             $result = await $result->resolveAsync();
         }

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -113,7 +113,16 @@ final class Resolver {
                 throw new \Error('Unsupported operation: '.$operation_type);
         }
 
-        return tuple($result->getValue(), $result->getErrors());
+        while ($result->isDeferred()) {
+            // This is where we'd batch load data for all pending promises
+            $result = await $result->resolveAsync();
+        }
+
+        if ($result is ValidFieldResult<_>) {
+            return tuple($result->getValue(), $result->getErrors());
+        } else {
+            return tuple(dict[], $result->getErrors());
+        }
     }
 
     private function coerceVariables(

--- a/src/Types/Input/InputType.hack
+++ b/src/Types/Input/InputType.hack
@@ -68,8 +68,7 @@ interface IInputTypeFor<THackType> extends IInputType {
     public function nullableInputListOf(): NullableInputType<vec<THackType>>;
 }
 
-interface INonNullableInputTypeFor<THackType as nonnull>
-    extends INonNullableType, IInputTypeFor<THackType> {}
+interface INonNullableInputTypeFor<THackType as nonnull> extends INonNullableType, IInputTypeFor<THackType> {}
 
 trait TInputType<THackType> implements IInputTypeFor<THackType> {
 
@@ -84,10 +83,7 @@ trait TInputType<THackType> implements IInputTypeFor<THackType> {
         dict<string, mixed> $variable_values,
     ): THackType;
 
-    final public function coerceNamedValue(
-        string $name,
-        KeyedContainer<arraykey, mixed> $values,
-    ): THackType {
+    final public function coerceNamedValue(string $name, KeyedContainer<arraykey, mixed> $values): THackType {
         try {
             return $this->coerceValue(idx($values, $name));
         } catch (GraphQL\UserFacingError $e) {

--- a/src/Types/Output/OutputType.hack
+++ b/src/Types/Output/OutputType.hack
@@ -61,6 +61,11 @@ trait TOutputType<THackType, TResolved> implements IOutputTypeFor<THackType, TRe
         return new NullableOutputType($this->nonNullableOutputListOf());
     }
 
+    <<__Memoize>>
+    final public function promise(): PromiseType<THackType, TResolved> {
+        return new PromiseType($this);
+    }
+
     public function resolveError(GraphQL\UserFacingError $error): GraphQL\FieldResult<TResolved> {
         return new GraphQL\InvalidFieldResult(vec[$error]);
     }

--- a/src/Types/Output/PromiseType.hack
+++ b/src/Types/Output/PromiseType.hack
@@ -1,0 +1,77 @@
+namespace Slack\GraphQL\Types;
+
+use namespace HH\Lib\Vec;
+use namespace Slack\GraphQL;
+use namespace Slack\GraphQL\Introspection;
+
+final class PromiseType<TInner, TResolved> extends BaseType implements IOutputTypeFor<GraphQL\Promise<TInner>, TResolved> {
+    use TOutputType<GraphQL\Promise<TInner>, TResolved>;
+
+    public function __construct(private IOutputTypeFor<TInner, TResolved> $innerType) {}
+
+    public async function resolveAsync(
+        GraphQL\Promise<TInner> $value,
+        vec<\Graphpinator\Parser\Field\IHasSelectionSet> $parent_nodes,
+        GraphQL\ExecutionContext $context,
+    ): Awaitable<GraphQL\FieldResult<TResolved>> {
+        $value = await $value->resolve();
+        return await $this->innerType->resolveAsync($value, $parent_nodes, $context);
+    }
+
+    public function unwrapType(): INamedOutputType {
+        return $this->innerType->unwrapType();
+    }
+
+    public function getInnerType(): IOutputTypeFor<TInner, TResolved> {
+        return $this->innerType;
+    }
+
+    <<__Override>>
+    final public function getIntrospectionKind(): Introspection\__TypeKind {
+        return $this->getInnerType()->getIntrospectionKind();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionName(): ?string {
+        return $this->getInnerType()->getIntrospectionName();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionDescription(): ?string {
+        return $this->getInnerType()->getIntrospectionDescription();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionFields(bool $include_deprecated = false): ?vec<Introspection\__Field> {
+        return $this->getInnerType()->getIntrospectionFields();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionInterfaces(): ?vec<Introspection\__Type> {
+        return $this->getInnerType()->getIntrospectionInterfaces();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionPossibleTypes(): ?vec<Introspection\__Type> {
+        return $this->getInnerType()->getIntrospectionPossibleTypes();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionEnumValues(
+        bool $include_deprecated = false,
+    ): ?vec<Introspection\__EnumValue> {
+        return $this->getInnerType()->getIntrospectionEnumValues();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionInputFields(
+        bool $include_deprecated = false,
+    ): ?vec<Introspection\__InputValue> {
+        return $this->getInnerType()->getIntrospectionInputFields();
+    }
+
+    <<__Override>>
+    final public function getIntrospectionOfType(): ?Introspection\__Type {
+        return $this->getInnerType()->getIntrospectionOfType();
+    }
+}

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -52,7 +52,7 @@ interface User {
     public function getName(): string;
 
     <<GraphQL\Field('team', 'Team the user belongs to')>>
-    public function getTeam(): Awaitable<\Team>;
+    public function getTeam(): GraphQL\Promise<\Team>;
 
     <<GraphQL\Field('is_active', 'Whether the user is active')>>
     public function isActive(): bool;
@@ -76,8 +76,8 @@ abstract class BaseUser implements User {
         return $this->data['name'];
     }
 
-    public async function getTeam(): Awaitable<\Team> {
-        return await TeamStore::getInstance()->getById($this->data['team_id']);
+    public function getTeam(): GraphQL\Promise<Team> {
+        return new GraphQL\Promise(async () ==> await TeamStore::getInstance()->getById($this->data['team_id']));
     }
 
     public function isActive(): bool {

--- a/src/playground/Playground.hack
+++ b/src/playground/Playground.hack
@@ -144,23 +144,61 @@ final class Team {
 
 abstract final class UserQueryAttributes {
     <<GraphQL\QueryRootField('viewer', 'Authenticated viewer')>>
-    public static async function getViewer(): Awaitable<\User> {
-        return new \Human(shape('id' => 1, 'name' => 'Test User', 'team_id' => 1, 'is_active' => true));
+    public static function getViewer(): GraphQL\Promise<\User> {
+        return new GraphQL\Promise(async () ==> new \Human(shape(
+            'id' => 1,
+            'name' => 'Test User',
+            'team_id' => 1,
+            'is_active' => true
+        )));
     }
 
     <<GraphQL\QueryRootField('user', 'Fetch a user by ID')>>
-    public static async function getUser(int $id): Awaitable<\User> {
-        return new \Human(shape('id' => $id, 'name' => 'User '.$id, 'team_id' => 1, 'is_active' => true));
+    public static function getUser(int $id): GraphQL\Promise<\User> {
+        return new GraphQL\Promise(async () ==> new \Human(shape(
+            'id' => $id,
+            'name' => 'User '.$id,
+            'team_id' => 1,
+            'is_active' => true
+        )));
     }
 
     <<GraphQL\QueryRootField('human', 'Fetch a user by ID')>>
-    public static async function getHuman(int $id): Awaitable<\Human> {
-        return new \Human(shape('id' => $id, 'name' => 'User '.$id, 'team_id' => 1, 'is_active' => true));
+    public static function getHuman(int $id): GraphQL\Promise<\Human> {
+        return new GraphQL\Promise(async () ==> new \Human(shape(
+            'id' => $id,
+            'name' => 'User '.$id,
+            'team_id' => 1,
+            'is_active' => true
+        )));
     }
 
     <<GraphQL\QueryRootField('bot', 'Fetch a bot by ID')>>
-    public static async function getBot(int $id): Awaitable<\Bot> {
-        return new \Bot(shape('id' => $id, 'name' => 'User '.$id, 'team_id' => 1, 'is_active' => true));
+    public static function getBot(int $id): GraphQL\Promise<\Bot> {
+        return new GraphQL\Promise(async () ==> new \Bot(shape(
+            'id' => $id,
+            'name' => 'User '.$id,
+            'team_id' => 1,
+            'is_active' => true
+        )));
+    }
+
+    <<GraphQL\QueryRootField('listHumans', 'Fetch multiple')>>
+    public static function listUsers(vec<int> $ids): GraphQL\Promise<vec<\User>> {
+        return new GraphQL\Promise(async () ==> vec[
+            new \Bot(shape(
+                'id' => 1,
+                'name' => 'User 1',
+                'team_id' => 1,
+                'is_active' => true
+            )),
+            new \Human(shape(
+                'id' => 2,
+                'name' => 'User 2',
+                'team_id' => 1,
+                'is_active' => true
+            )),
+        ]);
     }
 
     <<GraphQL\QueryRootField('nested_list_sum', 'Test for nested list arguments')>>

--- a/tests/BasicTest.hack
+++ b/tests/BasicTest.hack
@@ -61,6 +61,41 @@ final class BasicTest extends PlaygroundTest {
                 dict['favorite_color' => 'RED'],
                 dict['takes_favorite_color' => true],
             ),
+            'promise resolving to a list with nested promises' => tuple(
+                '
+                query {
+                    listHumans(ids: [1, 2]) {
+                        id
+                        name
+                        team {
+                            id
+                            name
+                        }
+                    }
+                }
+                ',
+                dict[],
+                dict[
+                    'listHumans' => vec[
+                        dict[
+                            'id' => 1,
+                            'name' => 'User 1',
+                            'team' => dict[
+                                'id' => 1,
+                                'name' => 'Test Team 1',
+                            ],
+                        ],
+                        dict[
+                            'id' => 2,
+                            'name' => 'User 2',
+                            'team' => dict[
+                                'id' => 1,
+                                'name' => 'Test Team 1',
+                            ],
+                        ],
+                    ],
+                ],
+            ),
         ];
     }
 }

--- a/tests/gen/Bot.hack
+++ b/tests/gen/Bot.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<803c718476e0461c3e9d70a1db853f34>>
+ * @generated SignedSource<<22cb1cb75d950b44643784ed0b056eac>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -61,9 +61,9 @@ final class Bot extends \Slack\GraphQL\Types\ObjectType {
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
-          Team::nullableOutput(),
+          Team::nonNullable()->promise(),
           dict[],
-          async ($parent, $args, $vars) ==> await $parent->getTeam(),
+          async ($parent, $args, $vars) ==> $parent->getTeam(),
         );
       default:
         return null;

--- a/tests/gen/Human.hack
+++ b/tests/gen/Human.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<610ad67a380dfcc24d35298d39f1ba7a>>
+ * @generated SignedSource<<8a9e54d5c6e7d11e6a80d9a903886b6e>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -135,9 +135,9 @@ final class Human extends \Slack\GraphQL\Types\ObjectType {
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
-          Team::nullableOutput(),
+          Team::nonNullable()->promise(),
           dict[],
-          async ($parent, $args, $vars) ==> await $parent->getTeam(),
+          async ($parent, $args, $vars) ==> $parent->getTeam(),
         );
       default:
         return null;

--- a/tests/gen/Query.hack
+++ b/tests/gen/Query.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<2e87035d3a1c154b45a8a4229f2f3c61>>
+ * @generated SignedSource<<1bfd781fc2416ebbfe2f37dc6d925ce2>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -29,6 +29,7 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
     'getObjectShape',
     'human',
     'introspection_test',
+    'listHumans',
     'list_arg_test',
     'nested_list_sum',
     'optional_field_test',
@@ -126,14 +127,14 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
       case 'bot':
         return new GraphQL\FieldDefinition(
           'bot',
-          Bot::nullableOutput(),
+          Bot::nonNullable()->promise(),
           dict[
             'id' => shape(
               'name' => 'id',
               'type' => Types\IntType::nonNullable(),
             ),
           ],
-          async ($parent, $args, $vars) ==> await \UserQueryAttributes::getBot(
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::getBot(
             Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),
         );
@@ -182,14 +183,14 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
       case 'human':
         return new GraphQL\FieldDefinition(
           'human',
-          Human::nullableOutput(),
+          Human::nonNullable()->promise(),
           dict[
             'id' => shape(
               'name' => 'id',
               'type' => Types\IntType::nonNullable(),
             ),
           ],
-          async ($parent, $args, $vars) ==> await \UserQueryAttributes::getHuman(
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::getHuman(
             Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),
         );
@@ -199,6 +200,20 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
           IntrospectionTestObject::nullableOutput(),
           dict[],
           async ($parent, $args, $vars) ==> \IntrospectionTestObject::get(),
+        );
+      case 'listHumans':
+        return new GraphQL\FieldDefinition(
+          'listHumans',
+          User::nonNullable()->nonNullableOutputListOf()->promise(),
+          dict[
+            'ids' => shape(
+              'name' => 'ids',
+              'type' => Types\IntType::nonNullable()->nonNullableInputListOf(),
+            ),
+          ],
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::listUsers(
+            Types\IntType::nonNullable()->nonNullableInputListOf()->coerceNamedNode('ids', $args, $vars),
+          ),
         );
       case 'list_arg_test':
         return new GraphQL\FieldDefinition(
@@ -266,23 +281,23 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
       case 'user':
         return new GraphQL\FieldDefinition(
           'user',
-          User::nullableOutput(),
+          User::nonNullable()->promise(),
           dict[
             'id' => shape(
               'name' => 'id',
               'type' => Types\IntType::nonNullable(),
             ),
           ],
-          async ($parent, $args, $vars) ==> await \UserQueryAttributes::getUser(
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::getUser(
             Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),
         );
       case 'viewer':
         return new GraphQL\FieldDefinition(
           'viewer',
-          User::nullableOutput(),
+          User::nonNullable()->promise(),
           dict[],
-          async ($parent, $args, $vars) ==> await \UserQueryAttributes::getViewer(),
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::getViewer(),
         );
       default:
         return null;

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<05cd729532a7ff7c84a04aff87401a1f>>
+ * @generated SignedSource<<17b20a277551a5f3ff9aaa5a9ec30278>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -60,14 +60,14 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
   public static async function resolveQuery(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\ExecutionContext $context,
-  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
+  ): Awaitable<GraphQL\FieldResult<?dict<string, mixed>>> {
     return await Query::nullableOutput()->resolveAsync(new GraphQL\Root(), vec[$operation], $context);
   }
 
   public static async function resolveMutation(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\ExecutionContext $context,
-  ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
+  ): Awaitable<GraphQL\FieldResult<?dict<string, mixed>>> {
     return await Mutation::nullableOutput()->resolveAsync(new GraphQL\Root(), vec[$operation], $context);
   }
 }

--- a/tests/gen/User.hack
+++ b/tests/gen/User.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<481a5396998f1863b06a6992d837fe3b>>
+ * @generated SignedSource<<b4b185b29e84e6b7875d1dfbeb73fe51>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -54,9 +54,9 @@ final class User extends \Slack\GraphQL\Types\InterfaceType {
       case 'team':
         return new GraphQL\FieldDefinition(
           'team',
-          Team::nullableOutput(),
+          Team::nonNullable()->promise(),
           dict[],
-          async ($parent, $args, $vars) ==> await $parent->getTeam(),
+          async ($parent, $args, $vars) ==> $parent->getTeam(),
         );
       default:
         return null;


### PR DESCRIPTION
This is an attempt to support promises, which we'll need if we want to use the DataLoader pattern to batch queries.

* Methods annotated with GraphQL\Field may return a Hack object with a valid GQL output representation wrapped in a `GraphQL\Promise<T>`; e.g., `Promise<Team>`.
* Codegen will special case these fields and see that they use a new `PromiseType<T>` instead of `T` directly.
* `PromiseType<T>` delegates all introspection to `T`.
* When resolved, `PromiseType<T>` returns a result of type `DeferredFieldResult<T>`.
* If an `ObjectType`, `ListOutputType`, or `NullableOutputType` detects that it will be returning a result which is or contains a `DeferredFieldResult`, it will return a `DeferredFieldResult` containing a callback which will continue resolution.
* The resolver checks if the result from calling `await $schema::resolveQuery` (or mutation) is itself a `DeferredFieldResult`. If so, it continues calling `resolveAsync()` on that field result until it receives a non-deferred result. Note that this will only happen once the top-level deferred result contains no more deferred results (because of the prior bullet point).
* This means that each time the resolver calls `resolveAsync()` on the deferred result, _all_ currently known deferred results will resolve. The next set of deferred results, should any exist, will be any new deferred result returned by calling `resolveAsync()` on each `DeferredFieldResult`. This means that between calls to `resolveAsync()` at the top-level is the perfect place to invoke the data loading framework and load batched data for all pending promises.

...Anyway. This is pretty rough, and I'm eager for feedback. Curious whether using `FieldResult` in this way makes sense or if there's a better approach. This is just what I came up with that seemed to result in the smallest amount of change to existing code.