### PR TITLE
Support verbose field resolver errors

### DIFF
--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -14,7 +14,12 @@ final class Resolver {
         ?'extensions' => dict<string, mixed>,
     );
 
-    public function __construct(private classname<BaseSchema> $schema) {}
+    const type TOptions = shape(
+        // Enabling this causes errors to include information about the underlying error.
+        ?'verbose_errors' => bool,
+    );
+
+    public function __construct(private classname<BaseSchema> $schema, private this::TOptions $options = shape()) {}
 
     /**
      * Operation name must be specified if the GraphQL request contains multiple operations.
@@ -146,6 +151,6 @@ final class Resolver {
     }
 
     private function formatErrors(vec<UserFacingError> $errors): vec<UserFacingError::TData> {
-        return Vec\map($errors, $error ==> $error->toShape());
+        return Vec\map($errors, $error ==> $error->toShape($this->options['verbose_errors'] ?? false));
     }
 }

--- a/src/UserFacingError.hack
+++ b/src/UserFacingError.hack
@@ -16,7 +16,7 @@ class UserFacingError extends \Exception {
         'message' => string,
         ?'location' => shape('line' => int, 'column' => int),
         ?'path' => vec<arraykey>,
-        ?'cause' => shape(
+        ?'extensions' => shape(
             'message' => string,
             'file' => string,
             'line' => int,
@@ -78,7 +78,7 @@ class UserFacingError extends \Exception {
         }
         if ($verbose && $this is FieldResolverError) {
             $cause = $this->getCause();
-            $out['cause'] = shape(
+            $out['extensions'] = shape(
                 'message' => $cause->getMessage(),
                 'file' => $cause->getFile(),
                 'line' => $cause->getLine(),

--- a/tests/ErrorTest.hack
+++ b/tests/ErrorTest.hack
@@ -405,9 +405,9 @@ final class ErrorTest extends PlaygroundTest {
         expect($error['path'] ?? null)->toEqual(vec['error_test', 'hidden_exception']);
         expect($error['location'] ?? null)->toBeNull();
 
-        $cause = expect($error['cause'] ?? null)->toNotBeNull();
-        expect($cause['message'])->toEqual('Could not connect to database at 127.0.0.1');
-        expect($cause['file'])->toContainSubstring('playground/ErrorTestObj.hack');
-        expect($cause['line'])->toEqual(35);
+        $extension = expect($error['extensions'] ?? null)->toNotBeNull();
+        expect($extension['message'])->toEqual('Could not connect to database at 127.0.0.1');
+        expect($extension['file'])->toContainSubstring('playground/ErrorTestObj.hack');
+        expect($extension['line'])->toEqual(35);
     }
 }

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -41,15 +41,16 @@ abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
         expect($out)->toHaveSameShapeAs($expected_response);
     }
 
-    private function getResolver(): GraphQL\Resolver {
-        return new GraphQL\Resolver(\Slack\GraphQL\Test\Generated\Schema::class);
+    private function getResolver(GraphQL\Resolver::TOptions $options = shape()): GraphQL\Resolver {
+        return new GraphQL\Resolver(\Slack\GraphQL\Test\Generated\Schema::class, $options);
     }
 
     public async function resolve(
         string $query,
         dict<string, mixed> $variables = dict[],
+        GraphQL\Resolver::TOptions $options = shape(),
     ): Awaitable<GraphQL\Resolver::TResponse> {
-        $resolver = $this->getResolver();
+        $resolver = $this->getResolver($options);
         return await $resolver->resolve($query, $variables);
     }
 }


### PR DESCRIPTION
Adds a new option to the resolver, `verbose_errors`. When enabled, we also surface the cause of each `FieldResolverError`.