### PR TITLE
Always use schema instance

### DIFF
--- a/src/BaseSchema.hack
+++ b/src/BaseSchema.hack
@@ -1,6 +1,6 @@
 namespace Slack\GraphQL;
 
-use namespace HH\Lib\{Dict, Keyset, Vec, Str};
+use namespace HH\Lib\{Dict, Vec, Str};
 
 // TODO: this should be private
 <<__ConsistentConstruct>>

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -180,7 +180,6 @@ final class Generator {
 
         $resolve_method = $cg->codegenMethod($method_name)
             ->setPublic()
-            ->setIsStatic(true)
             ->setIsAsync(true)
             ->setReturnType('Awaitable<GraphQL\\ValidFieldResult<?dict<string, mixed>>>')
             ->addParameterf('\%s $operation', \Graphpinator\Parser\Operation\Operation::class)

--- a/src/Resolver.hack
+++ b/src/Resolver.hack
@@ -19,7 +19,7 @@ final class Resolver {
         ?'verbose_errors' => bool,
     );
 
-    public function __construct(private classname<BaseSchema> $schema, private this::TOptions $options = shape()) {}
+    public function __construct(private BaseSchema $schema, private this::TOptions $options = shape()) {}
 
     /**
      * Operation name must be specified if the GraphQL request contains multiple operations.
@@ -108,11 +108,11 @@ final class Resolver {
         $operation_type = $operation->getType();
         switch ($operation_type) {
             case 'query':
-                $result = await $schema::resolveQuery($operation, $context);
+                $result = await $schema->resolveQuery($operation, $context);
                 break;
             case 'mutation':
                 invariant($schema::MUTATION_TYPE, 'mutation operation not supported for schema');
-                $result = await $schema::resolveMutation($operation, $context);
+                $result = await $schema->resolveMutation($operation, $context);
                 break;
             default:
                 throw new \Error('Unsupported operation: '.$operation_type);

--- a/src/Types/Input/InputType.hack
+++ b/src/Types/Input/InputType.hack
@@ -170,7 +170,7 @@ trait TInputType<THackType> implements IInputTypeFor<THackType> {
      * Convert a parser node (e.g. from a variable declaration) to an instance of the input type it represents.
      */
     public static function fromNode(
-        classname<GraphQL\BaseSchema> $schema,
+        GraphQL\BaseSchema $schema,
         TypeRef\TypeRef $node,
         bool $nullable = true,
     ): IInputType {

--- a/src/Validation/Rules/KnownTypeNamesRule.hack
+++ b/src/Validation/Rules/KnownTypeNamesRule.hack
@@ -4,8 +4,7 @@ final class KnownTypeNamesRule extends ValidationRule {
     <<__Override>>
     public function enter(\Graphpinator\Parser\Node $node): void {
         if ($node is \Graphpinator\Parser\TypeRef\NamedTypeRef) {
-            $schema = $this->context->getSchema();
-            $type = (new $schema())->getIntrospectionType($node->getName());
+            $type = $this->context->getSchema()->getIntrospectionType($node->getName());
             if ($type is null) {
                 $this->reportError($node, 'Unknown type "%s".', $node->getName());
             }

--- a/src/Validation/ValidationContext.hack
+++ b/src/Validation/ValidationContext.hack
@@ -9,7 +9,7 @@ final class ValidationContext {
     private vec<\Slack\GraphQL\UserFacingError> $errors = vec[];
 
     public function __construct(
-        private classname<\Slack\GraphQL\BaseSchema> $schema,
+        private \Slack\GraphQL\BaseSchema $schema,
         private Parser\ParsedRequest $ast,
         private TypeInfo $type_info,
     ) {}
@@ -29,7 +29,7 @@ final class ValidationContext {
         return $this->errors;
     }
 
-    public function getSchema(): classname<\Slack\GraphQL\BaseSchema> {
+    public function getSchema(): \Slack\GraphQL\BaseSchema {
         return $this->schema;
     }
 

--- a/src/Validation/Validator.hack
+++ b/src/Validation/Validator.hack
@@ -13,7 +13,7 @@ final class Validator {
         ScalarLeafsRule::class,
     ];
 
-    public function __construct(private classname<\Slack\GraphQL\BaseSchema> $schema) {}
+    public function __construct(private \Slack\GraphQL\BaseSchema $schema) {}
 
     public function validate(\Graphpinator\Parser\ParsedRequest $request): vec<\Slack\GraphQL\UserFacingError> {
         $dependencies = new DependencyInfo();

--- a/src/__Private/Visitor/TypeInfo.hack
+++ b/src/__Private/Visitor/TypeInfo.hack
@@ -15,7 +15,7 @@ use type \Slack\GraphQL\__Private\Utils\Stack;
  */
 final class TypeInfo extends ASTVisitor {
 
-    private classname<\Slack\GraphQL\BaseSchema> $schema;
+    private \Slack\GraphQL\BaseSchema $schema;
     private Stack<?Types\IOutputType> $type_stack;
     private Stack<?Types\INamedOutputType> $parent_type_stack;
     private Stack<?Types\IInputType> $input_type_stack;
@@ -23,7 +23,7 @@ final class TypeInfo extends ASTVisitor {
     private Stack<mixed> $default_value_stack;
     private ?\Slack\GraphQL\Introspection\__InputValue $argument = null;
 
-    public function __construct(classname<\Slack\GraphQL\BaseSchema> $schema) {
+    public function __construct(\Slack\GraphQL\BaseSchema $schema) {
         $this->schema = $schema;
         $this->type_stack = new Stack();
         $this->parent_type_stack = new Stack();
@@ -78,13 +78,12 @@ final class TypeInfo extends ASTVisitor {
             $this->field_def_stack->push($field_definition);
             $this->type_stack->push($field_type);
         } elseif ($node is Parser\Operation\Operation) {
-            $schema = $this->schema;
             switch ($node->getType()) {
                 case \Graphpinator\Tokenizer\OperationType::QUERY:
-                    $type = $schema::getQueryType();
+                    $type = $this->schema->getQueryType();
                     break;
                 case \Graphpinator\Tokenizer\OperationType::MUTATION:
-                    $type = $schema::getMutationType();
+                    $type = $this->schema->getMutationType();
                     break;
                 default:
                     // TODO: Subscriptions
@@ -95,10 +94,9 @@ final class TypeInfo extends ASTVisitor {
             $node is Parser\FragmentSpread\InlineFragmentSpread ||
             $node is Parser\Fragment\Fragment
         ) {
-            $schema = $this->schema;
             $type_condition = $node->getTypeCond();
             $output_type = $type_condition
-                ? (new $schema())->getType($type_condition->getName())
+                ? $this->schema->getType($type_condition->getName())
                 : $this->getType();
             $this->type_stack->push($output_type is Types\IOutputType ? $output_type : null);
         } elseif ($node is Parser\Value\ArgumentValue) {

--- a/tests/PlaygroundTest.hack
+++ b/tests/PlaygroundTest.hack
@@ -42,7 +42,7 @@ abstract class PlaygroundTest extends \Facebook\HackTest\HackTest {
     }
 
     private function getResolver(GraphQL\Resolver::TOptions $options = shape()): GraphQL\Resolver {
-        return new GraphQL\Resolver(\Slack\GraphQL\Test\Generated\Schema::class, $options);
+        return new GraphQL\Resolver(new \Slack\GraphQL\Test\Generated\Schema(), $options);
     }
 
     public async function resolve(

--- a/tests/Validation/BaseValidationTest.hack
+++ b/tests/Validation/BaseValidationTest.hack
@@ -31,7 +31,7 @@ abstract class BaseValidationTest extends \Facebook\HackTest\HackTest {
         $parser = new \Graphpinator\Parser\Parser($source);
         $request = $parser->parse();
 
-        $validator = new GraphQL\Validation\Validator(GraphQL\Test\Generated\Schema::class);
+        $validator = new GraphQL\Validation\Validator(new GraphQL\Test\Generated\Schema());
         $validator->setRules(keyset[$this::RULE]);
 
         $errors = $validator->validate($request);

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<69541b064478e524d71bfde9973652e8>>
+ * @generated SignedSource<<ca884de171baec7363f2937226e46573>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -62,14 +62,14 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
   const classname<\Slack\GraphQL\Types\ObjectType> QUERY_TYPE = Query::class;
   const classname<\Slack\GraphQL\Types\ObjectType> MUTATION_TYPE = Mutation::class;
 
-  public static async function resolveQuery(
+  public async function resolveQuery(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {
     return await Query::nullableOutput()->resolveAsync(new GraphQL\Root(), vec[$operation], $context);
   }
 
-  public static async function resolveMutation(
+  public async function resolveMutation(
     \Graphpinator\Parser\Operation\Operation $operation,
     \Slack\GraphQL\ExecutionContext $context,
   ): Awaitable<GraphQL\ValidFieldResult<?dict<string, mixed>>> {


### PR DESCRIPTION
This is a small refactor I've been wanting to get in for awhile. We should always pass around an instance of `BaseSchema` instead of `classname<BaseSchema>`, for consistency's sake.