### PR TITLE
Add request/response interfaces

### DIFF
--- a/src/Request.hack
+++ b/src/Request.hack
@@ -1,0 +1,137 @@
+namespace Slack\GraphQL;
+
+use namespace Slack\GraphQL;
+use namespace HH\Lib\C;
+
+/**
+ * IRequest represents a request to the GraphQL server. The request may be wellformed or malformed;
+ * in the case of a malformed request, parsing has failed and the request will not be further validated
+ * or executed.
+ *
+ * This interface mostly exists as a way to pass useful metadata back to the client; e.g. callers can
+ * call `$request->getOperationName()` to discover the name of the GraphQL query or mutation which the
+ * request would execute.
+ */
+interface IRequest {
+    public function getVariables(): dict<string, mixed>;
+    public function getOperationName(): ?string;
+}
+
+abstract class Request implements IRequest {
+    /**
+     * Build a GraphQL request.
+     *
+     * A request contains at leat one operation. An operation name must be provided if the request
+     * contains multiple operations.
+     *
+     * @see https://spec.graphql.org/draft/#sec-Execution
+     */
+    final public static function build(
+        string $input,
+        dict<string, mixed> $variables = dict[],
+        ?string $operation_name = null,
+    ): IRequest {
+        try {
+            $query = self::parseQuery($input);
+            $operation = self::parseOperation($query, $operation_name);
+        } catch (UserFacingError $error) {
+            return new MalformedRequest(vec[$error], $input, $variables, $operation_name);
+        }
+
+        return new WellformedRequest($query, $operation, $input, $variables);
+    }
+
+    private static function parseOperation(
+        \Graphpinator\Parser\ParsedRequest $query,
+        ?string $operation_name,
+    ): \Graphpinator\Parser\Operation\Operation {
+        if ($operation_name is nonnull) {
+            GraphQL\assert(
+                C\contains_key($query->getOperations(), $operation_name),
+                'Operation %s not found in the request',
+                $operation_name,
+            );
+            return $query->getOperations()[$operation_name];
+        } else {
+            GraphQL\assert(
+                C\count($query->getOperations()) === 1,
+                'Operation name must be specified if the request contains multiple',
+            );
+            return C\onlyx($query->getOperations());
+        }
+    }
+
+    private static function parseQuery(string $input): \Graphpinator\Parser\ParsedRequest {
+        $source = new \Graphpinator\Source\StringSource($input);
+        $parser = new \Graphpinator\Parser\Parser($source);
+
+        try {
+            return $parser->parse();
+        } catch (\Graphpinator\Exception\GraphpinatorBase $e) {
+            $user_facing_error = new UserFacingError('%s', $e->getMessage());
+            $location = $e->getLocation();
+            if ($location) {
+                $user_facing_error->setLocation($location);
+            }
+            $path = $e->getPath()?->jsonSerialize();
+            if ($path) {
+                $user_facing_error->setPath($path);
+            }
+            throw $user_facing_error;
+        }
+    }
+
+    public function __construct(private string $input, private dict<string, mixed> $variables = dict[]) {}
+
+    public function getVariables(): dict<string, mixed> {
+        return $this->variables;
+    }
+}
+
+/**
+ * A request that could not be parsed or that contained an invalid operation name.
+ */
+final class MalformedRequest extends Request {
+    public function __construct(
+        private vec<UserFacingError> $errors,
+        string $input,
+        dict<string, mixed> $variables = dict[],
+        private ?string $operation_name = null,
+    ) {
+        parent::__construct($input, $variables);
+    }
+
+    public function getErrors(): vec<UserFacingError> {
+        return $this->errors;
+    }
+
+    public function getOperationName(): ?string {
+        return $this->operation_name;
+    }
+}
+
+/**
+ * A parsed request which is ready to be validated and potentially executed.
+ */
+final class WellformedRequest extends Request {
+    public function __construct(
+        private \Graphpinator\Parser\ParsedRequest $query,
+        private \Graphpinator\Parser\Operation\Operation $operation,
+        string $input,
+        dict<string, mixed> $variables = dict[],
+    ) {
+        parent::__construct($input, $variables);
+    }
+
+    public function getQuery(): \Graphpinator\Parser\ParsedRequest {
+        return $this->query;
+    }
+
+    public function getOperation(): \Graphpinator\Parser\Operation\Operation {
+        return $this->operation;
+    }
+
+    public function getOperationName(): string {
+        return $this->operation->getName();
+    }
+}

--- a/src/Response.hack
+++ b/src/Response.hack
@@ -2,6 +2,10 @@ namespace Slack\GraphQL;
 
 use namespace HH\Lib\Vec;
 
+/**
+ * A GraphQL response providing access to data and errors output by the resolver,
+ * as well as to the GraphQL request.
+ */
 interface IResponse {
 
     /**
@@ -13,12 +17,32 @@ interface IResponse {
         ?'extensions' => dict<string, mixed>,
     );
 
+    /**
+     * Get the data output by the resolver.
+     */
     public function getData(): ?dict<string, mixed>;
+
+    /**
+     * Get any errors which occurred in the process of parsing, validating and resolving the request.
+     */
     public function getErrors(): ?vec<UserFacingError>;
+
+    /**
+     * Get the request which gave rise to this response.
+     */
     public function getRequest(): IRequest;
+
+    /**
+     * Cast the GraphQL response to a shape with `data`, `errors`, and `extensions` properties.
+     */
     public function toShape(bool $verbose = false): this::TShape;
 }
 
+/**
+ * An internal representation of a GraphQL response.
+ *
+ * Allows for mutating operations which are not exposed to downstream consumers.
+ */
 final class Response implements IResponse {
     private vec<UserFacingError> $errors = vec[];
 
@@ -26,28 +50,14 @@ final class Response implements IResponse {
     // which threw an exception. An empty dict, on the other hand, means we never invoked any resolvers.
     private ?dict<string, mixed> $data = dict[];
 
-    public function __construct(private IRequest $request) {
-        if ($request is MalformedRequest) {
-            $this->errors = $request->getErrors();
-        }
-    }
+    public function __construct(private IRequest $request) {}
 
     public function getData(): ?dict<string, mixed> {
         return $this->data;
     }
 
-    public function withData(?dict<string, mixed> $data): this {
-        $this->data = $data;
-        return $this;
-    }
-
     public function getErrors(): ?vec<UserFacingError> {
         return $this->errors;
-    }
-
-    public function withErrors(vec<UserFacingError> $errors): this {
-        $this->errors = $errors;
-        return $this;
     }
 
     public function getRequest(): IRequest {
@@ -63,5 +73,35 @@ final class Response implements IResponse {
             $ret['errors'] = Vec\map($this->errors, $error ==> $error->toShape($verbose));
         }
         return $ret;
+    }
+
+    /**
+     * Set the `data` and `errors` properties from the resolver response.
+     */
+    public function withResult(ValidFieldResult<?dict<string, mixed>> $result): this {
+        $this->data = $result->getValue();
+        return $this->withErrors($result->getErrors()); // Add any errors which might exist
+    }
+
+    /**
+     * Record an exception which occurred while resolving the request.
+     */
+    public function withException(\Throwable $error): this {
+        return $this->withErrors(vec[new FieldResolverError($error)]);
+    }
+
+    /**
+     * Record a user-facing error which occurred while resolving the request.
+     */
+    public function withUserError(UserFacingError $error): this {
+        return $this->withErrors(vec[$error]);
+    }
+
+    /**
+     * Record errors which occurred while resolving the request.
+     */
+    public function withErrors(vec<UserFacingError> $errors): this {
+        $this->errors = $errors;
+        return $this;
     }
 }

--- a/src/Response.hack
+++ b/src/Response.hack
@@ -21,6 +21,9 @@ interface IResponse {
 
 final class Response implements IResponse {
     private vec<UserFacingError> $errors = vec[];
+
+    // A null value here represents that the data has been "nulled-out" by a child resolver
+    // which threw an exception. An empty dict, on the other hand, means we never invoked any resolvers.
     private ?dict<string, mixed> $data = dict[];
 
     public function __construct(private IRequest $request) {

--- a/src/Response.hack
+++ b/src/Response.hack
@@ -1,0 +1,64 @@
+namespace Slack\GraphQL;
+
+use namespace HH\Lib\Vec;
+
+interface IResponse {
+
+    /**
+     * @see https://spec.graphql.org/draft/#sec-Response
+     */
+    const type TShape = shape(
+        ?'data' => ?dict<string, mixed>, // missing data and null data are both valid states with different meanings
+        ?'errors' => vec<UserFacingError::TData>, // errors are optional but cannot be null (or empty) if present
+        ?'extensions' => dict<string, mixed>,
+    );
+
+    public function getData(): ?dict<string, mixed>;
+    public function getErrors(): ?vec<UserFacingError>;
+    public function getRequest(): IRequest;
+    public function toShape(bool $verbose = false): this::TShape;
+}
+
+final class Response implements IResponse {
+    private vec<UserFacingError> $errors = vec[];
+    private ?dict<string, mixed> $data = dict[];
+
+    public function __construct(private IRequest $request) {
+        if ($request is MalformedRequest) {
+            $this->errors = $request->getErrors();
+        }
+    }
+
+    public function getData(): ?dict<string, mixed> {
+        return $this->data;
+    }
+
+    public function withData(?dict<string, mixed> $data): this {
+        $this->data = $data;
+        return $this;
+    }
+
+    public function getErrors(): ?vec<UserFacingError> {
+        return $this->errors;
+    }
+
+    public function withErrors(vec<UserFacingError> $errors): this {
+        $this->errors = $errors;
+        return $this;
+    }
+
+    public function getRequest(): IRequest {
+        return $this->request;
+    }
+
+    public function toShape(bool $verbose = false): this::TShape {
+        $ret = shape();
+        if ($this->data is null || $this->data) {
+            $ret['data'] = $this->data;
+        }
+        if ($this->errors) {
+            $ret['errors'] = Vec\map($this->errors, $error ==> $error->toShape($verbose));
+        }
+        return $ret;
+    }
+}

--- a/tests/ErrorTest.hack
+++ b/tests/ErrorTest.hack
@@ -391,7 +391,7 @@ final class ErrorTest extends FixtureTest {
             }
             ',
             dict[],
-            shape('verbose_errors' => true),
+            true, // verbose_errors
         );
 
         expect($output['data'] ?? null)->toEqual(dict[

--- a/tests/FixtureTest.hack
+++ b/tests/FixtureTest.hack
@@ -44,16 +44,18 @@ abstract class FixtureTest extends \Facebook\HackTest\HackTest {
         expect($out)->toHaveSameShapeAs($expected_response);
     }
 
-    private function getResolver(GraphQL\Resolver::TOptions $options = shape()): GraphQL\Resolver {
-        return new GraphQL\Resolver(new \Slack\GraphQL\Test\Generated\Schema(), $options);
+    private function getResolver(): GraphQL\Resolver {
+        return new GraphQL\Resolver(new \Slack\GraphQL\Test\Generated\Schema());
     }
 
     public async function resolve(
         string $query,
         dict<string, mixed> $variables = dict[],
-        GraphQL\Resolver::TOptions $options = shape(),
-    ): Awaitable<GraphQL\Resolver::TResponse> {
-        $resolver = $this->getResolver($options);
-        return await $resolver->resolve($query, $variables);
+        bool $verbose_errors = false,
+    ): Awaitable<GraphQL\IResponse::TShape> {
+        $request = GraphQL\Request::build($query, $variables);
+        $resolver = $this->getResolver();
+        $response = await $resolver->resolve($request);
+        return $response->toShape($verbose_errors);
     }
 }

--- a/tests/Validation/BaseValidationTest.hack
+++ b/tests/Validation/BaseValidationTest.hack
@@ -35,7 +35,7 @@ abstract class BaseValidationTest extends \Facebook\HackTest\HackTest {
         $query = $parser->parse();
         $operation = C\firstx($query->getOperations());
 
-        $request = new GraphQL\WellformedRequest($query, $operation, $input);
+        $request = new GraphQL\WellformedRequest($input, dict[], $query, $operation);
 
         $validator = new GraphQL\Validation\Validator(new \Slack\GraphQL\Test\Generated\Schema());
         $validator->setRules(keyset[$this::RULE]);


### PR DESCRIPTION
Per discussion with @sarahhenkens, we want to create a convenient way to access the operation name for each GraphQL request (and other useful metadata, eventually). As such, we decided it would be convenient to create request/response interfaces exposing this information. So, instead of the following:

```hack
return await $resolver->resolve($input, $variables);
```

We would now do:

```hack
$request = GraphQL\Request::build($input, $variables);
$response = await $resolver->resolve($request);
return $response->toShape();
```

It's a bit more verbose, but somewhat more flexible, since we can now do things like `$request->getOperationName()` to retrieve the name of the operation which will be executed (if any).

We could provide a simpler interface:

```hack
$response = await $resolver->resolve($input, $variables);

// Get the operation name:
$operation_name = $response->getRequest()->getOperationName();

return $response->toShape();
```

However, I like having access to the `Request` object before calling `$resolver->resolve`, so that we can augment logs with the operation name before resolving the request. Definitely open to feedback here.