### PR TITLE
Better handling for namespaced objects

### DIFF
--- a/src/Codegen/Builders/ObjectBuilder.hack
+++ b/src/Codegen/Builders/ObjectBuilder.hack
@@ -3,7 +3,7 @@
 
 namespace Slack\GraphQL\Codegen;
 
-use namespace HH\Lib\{Vec, Str};
+use namespace HH\Lib\{C, Str, Vec};
 use type Facebook\HackCodegen\{
     CodegenClass,
     HackCodegenFactory,
@@ -63,8 +63,14 @@ class ObjectBuilder extends CompositeBuilder {
     }
 
     public static function forConnection(string $name, string $edge_name): ObjectBuilder {
+        // Remove namespace to generate a sane GQL name
+        // This means that connections in different namespaces can collide with each other;
+        // we could eventually fix that by merging the namespace and GQL name when
+        // generating the connection but doesn't seem worth it currently.
+        $gql_name = Str\split($name, '\\')
+            |> C\lastx($$);
         return new ObjectBuilder(
-            new \Slack\GraphQL\ObjectType($name, $name), // TODO: Description
+            new \Slack\GraphQL\ObjectType($gql_name, $gql_name), // TODO: Description
             $name, // hack type
             vec[ // fields
                 new MethodFieldBuilder(shape(

--- a/src/Codegen/Types.hack
+++ b/src/Codegen/Types.hack
@@ -3,7 +3,7 @@
 
 namespace Slack\GraphQL\Codegen;
 
-use namespace HH\Lib\Str;
+use namespace HH\Lib\{C, Str};
 use namespace Slack\GraphQL\Types;
 
 const dict<string, classname<Types\LeafType>> BUILTIN_TYPES = dict[
@@ -61,8 +61,14 @@ function output_type(
     $class = get_output_type($unwrapped);
     if ($class is null) {
         throw new \Error('GraphQL\Field return types must be scalar or be classes annnotated with a GraphQL attribute');
+    } elseif (Str\starts_with($class, 'Slack\\GraphQL\\')) {
+        $class = Str\strip_prefix($class, 'Slack\\GraphQL\\');
+    } else {
+        // Class is user-defined, strip off the namespace since the generated
+        // GQL type isn't namespaced
+        $class = Str\split($class, '\\') |> C\lastx($$);
     }
-    return shape('type' => Str\strip_prefix($class, 'Slack\\GraphQL\\').$suffix, 'needs_await' => $needs_await);
+    return shape('type' => $class.$suffix, 'needs_await' => $needs_await);
 }
 
 /**

--- a/tests/BasicTest.hack
+++ b/tests/BasicTest.hack
@@ -64,6 +64,10 @@ final class BasicTest extends FixtureTest {
                 dict['favorite_color' => 'RED'],
                 dict['takes_favorite_color' => true],
             ),
+            'namespaced return types' =>
+                tuple('{ getFoo { value } }', dict[], dict['getFoo' => dict['value' => 'bar']]),
+            'doubly-nested namespaced return types' =>
+                tuple('{ getBaz { value } }', dict[], dict['getBaz' => dict['value' => 'qux']]),
         ];
     }
 }

--- a/tests/Fixtures/NamespaceTestObjects.hack
+++ b/tests/Fixtures/NamespaceTestObjects.hack
@@ -1,10 +1,38 @@
 
 
 
-namespace Foo;
+namespace Foo {
+    use namespace Slack\GraphQL;
 
-<<\Slack\GraphQL\InterfaceType('FooInterface', 'Foo Interface')>>
-abstract class FooInterface {}
+    <<\Slack\GraphQL\InterfaceType('FooInterface', 'Foo Interface')>>
+    abstract class FooInterface {}
 
-<<\Slack\GraphQL\ObjectType('FooObject', 'Foo Object')>>
-final class FooObject extends FooInterface {}
+    <<\Slack\GraphQL\ObjectType('FooObject', 'Foo Object')>>
+    final class FooObject extends FooInterface {
+
+        <<\Slack\GraphQL\Field('value', 'Value of the obj')>>
+        public function getValue(): string {
+            return 'bar';
+        }
+    }
+
+    final class FooConnection extends GraphQL\Pagination\Connection {
+        const type TNode = FooObject;
+
+        protected async function fetch(
+            GraphQL\Pagination\PaginationArgs $args,
+        ): Awaitable<vec<GraphQL\Pagination\Edge<FooObject>>> {
+            return vec[new GraphQL\Pagination\Edge(new FooObject(), $this->encodeCursor((string)0))];
+        }
+    }
+}
+
+namespace Foo\Bar {
+    <<\Slack\GraphQL\ObjectType('Baz', 'Baz Object')>>
+    final class Baz {
+        <<\Slack\GraphQL\Field('value', 'Value of the obj')>>
+        public function getValue(): string {
+            return 'qux';
+        }
+    }
+}

--- a/tests/Fixtures/Playground.hack
+++ b/tests/Fixtures/Playground.hack
@@ -188,6 +188,21 @@ abstract final class UserQueryAttributes {
     public static function alphabetConnection(): AlphabetConnection {
         return new AlphabetConnection();
     }
+
+    <<GraphQL\QueryRootField('allFooObjects', 'Get all foo objects')>>
+    public static function allFooObjects(): Foo\FooConnection {
+        return new Foo\FooConnection();
+    }
+
+    <<GraphQL\QueryRootField('getFoo', 'Get the one foo object')>>
+    public static function getFoo(): Foo\FooObject {
+        return new Foo\FooObject();
+    }
+
+    <<GraphQL\QueryRootField('getBaz', 'Get the one baz object')>>
+    public static function getBaz(): Foo\Bar\Baz {
+        return new Foo\Bar\Baz();
+    }
 }
 
 abstract final class UserMutationAttributes {

--- a/tests/PaginationTest.hack
+++ b/tests/PaginationTest.hack
@@ -521,6 +521,32 @@ final class PaginationTest extends FixtureTest {
                     ],
                 ),
             ),
+
+            'namespaced connection' => tuple(
+                '
+                {
+                    allFooObjects {
+                        edges {
+                            node {
+                                value
+                            }
+                        }
+                    }
+                }
+                ',
+                dict[],
+                dict[
+                    'allFooObjects' => dict[
+                        'edges' => vec[
+                            dict[
+                                'node' => dict[
+                                    'value' => 'bar',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ),
         ];
     }
 }

--- a/tests/gen/Baz.hack
+++ b/tests/gen/Baz.hack
@@ -4,22 +4,21 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c985a69e69b4b26408709e41c2f0d2c5>>
+ * @generated SignedSource<<78317f3a7332839455ecbea5da091009>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
 use namespace HH\Lib\{C, Dict};
 
-final class FooObject extends \Slack\GraphQL\Types\ObjectType {
+final class Baz extends \Slack\GraphQL\Types\ObjectType {
 
-  const NAME = 'FooObject';
-  const type THackType = \Foo\FooObject;
+  const NAME = 'Baz';
+  const type THackType = \Foo\Bar\Baz;
   const keyset<string> FIELD_NAMES = keyset[
     'value',
   ];
   const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
-    'FooInterface' => FooInterface::class,
   ];
 
   public function getFieldDefinition(

--- a/tests/gen/FooConnection.hack
+++ b/tests/gen/FooConnection.hack
@@ -4,34 +4,41 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c985a69e69b4b26408709e41c2f0d2c5>>
+ * @generated SignedSource<<e1029d908221f970c227a2b80dff5be6>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
 use namespace HH\Lib\{C, Dict};
 
-final class FooObject extends \Slack\GraphQL\Types\ObjectType {
+final class FooConnection extends \Slack\GraphQL\Types\ObjectType {
 
-  const NAME = 'FooObject';
-  const type THackType = \Foo\FooObject;
+  const NAME = 'FooConnection';
+  const type THackType = \Foo\FooConnection;
   const keyset<string> FIELD_NAMES = keyset[
-    'value',
+    'edges',
+    'pageInfo',
   ];
   const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
-    'FooInterface' => FooInterface::class,
   ];
 
   public function getFieldDefinition(
     string $field_name,
   ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
     switch ($field_name) {
-      case 'value':
+      case 'edges':
         return new GraphQL\FieldDefinition(
-          'value',
-          Types\StringType::nullableOutput(),
+          'edges',
+          FooObjectEdge::nonNullable()->nullableOutputListOf(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->getValue(),
+          async ($parent, $args, $vars) ==> await $parent->getEdges(),
+        );
+      case 'pageInfo':
+        return new GraphQL\FieldDefinition(
+          'pageInfo',
+          PageInfo::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> await $parent->getPageInfo(),
         );
       default:
         return null;

--- a/tests/gen/FooObjectEdge.hack
+++ b/tests/gen/FooObjectEdge.hack
@@ -4,34 +4,41 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<c985a69e69b4b26408709e41c2f0d2c5>>
+ * @generated SignedSource<<96bd2ebd136797e7bb5774ad210a08b2>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
 use namespace Slack\GraphQL\Types;
 use namespace HH\Lib\{C, Dict};
 
-final class FooObject extends \Slack\GraphQL\Types\ObjectType {
+final class FooObjectEdge extends \Slack\GraphQL\Types\ObjectType {
 
-  const NAME = 'FooObject';
-  const type THackType = \Foo\FooObject;
+  const NAME = 'FooObjectEdge';
+  const type THackType = \Slack\GraphQL\Pagination\Edge<\Foo\FooObject>;
   const keyset<string> FIELD_NAMES = keyset[
-    'value',
+    'node',
+    'cursor',
   ];
   const dict<string, classname<Types\InterfaceType>> INTERFACES = dict[
-    'FooInterface' => FooInterface::class,
   ];
 
   public function getFieldDefinition(
     string $field_name,
   ): ?GraphQL\IResolvableFieldDefinition<this::THackType> {
     switch ($field_name) {
-      case 'value':
+      case 'node':
         return new GraphQL\FieldDefinition(
-          'value',
+          'node',
+          FooObject::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> $parent->getNode(),
+        );
+      case 'cursor':
+        return new GraphQL\FieldDefinition(
+          'cursor',
           Types\StringType::nullableOutput(),
           dict[],
-          async ($parent, $args, $vars) ==> $parent->getValue(),
+          async ($parent, $args, $vars) ==> $parent->getCursor(),
         );
       default:
         return null;

--- a/tests/gen/Query.hack
+++ b/tests/gen/Query.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<fd73b9d41b5e89b223e335d9e94ca6cc>>
+ * @generated SignedSource<<fa1ca424a98ff51976408a73d53305d4>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -16,12 +16,15 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
   const NAME = 'Query';
   const type THackType = \Slack\GraphQL\Root;
   const keyset<string> FIELD_NAMES = keyset[
+    'allFooObjects',
     'alphabetConnection',
     'arg_test',
     'bot',
     'error_test',
     'error_test_nn',
+    'getBaz',
     'getConcrete',
+    'getFoo',
     'getInterfaceA',
     'getInterfaceB',
     'getObjectShape',
@@ -62,6 +65,39 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
           async ($parent, $args, $vars) ==> (new Schema())->getIntrospectionType(
 
             Types\StringType::nonNullable()->coerceNamedNode('name', $args, $vars),
+          ),
+        );
+      case 'allFooObjects':
+        return new GraphQL\FieldDefinition(
+          'allFooObjects',
+          FooConnection::nullableOutput(),
+          dict[
+            'after' => shape(
+              'name' => 'after',
+              'type' => Types\StringType::nullableInput(),
+              'defaultValue' => 'null',
+            ),
+            'before' => shape(
+              'name' => 'before',
+              'type' => Types\StringType::nullableInput(),
+              'defaultValue' => 'null',
+            ),
+            'first' => shape(
+              'name' => 'first',
+              'type' => Types\IntType::nullableInput(),
+              'defaultValue' => 'null',
+            ),
+            'last' => shape(
+              'name' => 'last',
+              'type' => Types\IntType::nullableInput(),
+              'defaultValue' => 'null',
+            ),
+          ],
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::allFooObjects()->setPaginationArgs(
+            Types\StringType::nullableInput()->coerceOptionalNamedNode('after', $args, $vars, null),
+            Types\StringType::nullableInput()->coerceOptionalNamedNode('before', $args, $vars, null),
+            Types\IntType::nullableInput()->coerceOptionalNamedNode('first', $args, $vars, null),
+            Types\IntType::nullableInput()->coerceOptionalNamedNode('last', $args, $vars, null),
           ),
         );
       case 'alphabetConnection':
@@ -150,12 +186,26 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
           dict[],
           async ($parent, $args, $vars) ==> \ErrorTestObj::getNonNullable(),
         );
+      case 'getBaz':
+        return new GraphQL\FieldDefinition(
+          'getBaz',
+          Baz::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::getBaz(),
+        );
       case 'getConcrete':
         return new GraphQL\FieldDefinition(
           'getConcrete',
           Concrete::nullableOutput(),
           dict[],
           async ($parent, $args, $vars) ==> \Concrete::getConcrete(),
+        );
+      case 'getFoo':
+        return new GraphQL\FieldDefinition(
+          'getFoo',
+          FooObject::nullableOutput(),
+          dict[],
+          async ($parent, $args, $vars) ==> \UserQueryAttributes::getFoo(),
         );
       case 'getInterfaceA':
         return new GraphQL\FieldDefinition(

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<024a37e7259d3742ec2b1d7c931d239b>>
+ * @generated SignedSource<<28ca3795298b957dd1a0452383e71935>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -16,6 +16,7 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
   const dict<string, classname<Types\NamedType>> TYPES = dict[
     'AlphabetConnection' => AlphabetConnection::class,
     'AnotherObjectShape' => AnotherObjectShape::class,
+    'Baz' => Baz::class,
     'Boolean' => Types\BooleanType::class,
     'Bot' => Bot::class,
     'Concrete' => Concrete::class,
@@ -23,8 +24,10 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
     'CreateUserInput' => CreateUserInput::class,
     'ErrorTestObj' => ErrorTestObj::class,
     'FavoriteColor' => FavoriteColor::class,
+    'FooConnection' => FooConnection::class,
     'FooInterface' => FooInterface::class,
     'FooObject' => FooObject::class,
+    'FooObjectEdge' => FooObjectEdge::class,
     'Human' => Human::class,
     'IIntrospectionInterfaceA' => IIntrospectionInterfaceA::class,
     'IIntrospectionInterfaceB' => IIntrospectionInterfaceB::class,

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -79,6 +79,27 @@
                     "possibleTypes": null
                 },
                 {
+                    "kind": "OBJECT",
+                    "name": "Baz",
+                    "fields": [
+                        {
+                            "name": "value",
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
                     "kind": "SCALAR",
                     "name": "Boolean",
                     "fields": null,
@@ -504,6 +525,46 @@
                     "possibleTypes": null
                 },
                 {
+                    "kind": "OBJECT",
+                    "name": "FooConnection",
+                    "fields": [
+                        {
+                            "name": "edges",
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "FooObjectEdge",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "pageInfo",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "PageInfo",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
                     "kind": "INTERFACE",
                     "name": "FooInterface",
                     "fields": [],
@@ -521,7 +582,19 @@
                 {
                     "kind": "OBJECT",
                     "name": "FooObject",
-                    "fields": [],
+                    "fields": [
+                        {
+                            "name": "value",
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
                     "inputFields": null,
                     "interfaces": [
                         {
@@ -530,6 +603,38 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "FooObjectEdge",
+                    "fields": [
+                        {
+                            "name": "node",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "FooObject",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "cursor",
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -1533,6 +1638,54 @@
                     "name": "Query",
                     "fields": [
                         {
+                            "name": "allFooObjects",
+                            "args": [
+                                {
+                                    "name": "after",
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "null"
+                                },
+                                {
+                                    "name": "before",
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "null"
+                                },
+                                {
+                                    "name": "first",
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "null"
+                                },
+                                {
+                                    "name": "last",
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "Int",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": "null"
+                                }
+                            ],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "FooConnection",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "alphabetConnection",
                             "args": [
                                 {
@@ -1679,11 +1832,33 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "getBaz",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "Baz",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "getConcrete",
                             "args": [],
                             "type": {
                                 "kind": "OBJECT",
                                 "name": "Concrete",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "getFoo",
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "FooObject",
                                 "ofType": null
                             },
                             "isDeprecated": false,


### PR DESCRIPTION
We were generating bad code for namespaced connections. I fixed this by:

1. Removing the namespace for any resolver we pass into a field definition (i.e., any resolver generated by `output_type` that isn't a primitive resolver).
2. Removing the namespace when generating the name for the GraphQL connection.

This means that connections with the same name in different namespaces can collide. Eventually we could fix this by:
1. Merging the namespace name with the connection name.
2. Allowing user-provided connection names which differ from the Hack class name.

Neither solution seems necessary as of yet.

I also added a test asserting we handle namespaced return types correctly, which we do.