### PR TITLE
Fix bug for classes with non-graphql attribute classes

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -249,13 +249,9 @@ final class Generator {
                     $class->getName(),
                 );
                 $objects = Vec\concat($objects, $this->getConnectionObjects($class, $class_fields[$class->getName()]));
-            } elseif (!C\is_empty($class->getAttributes())) {
-                $fields = idx($class_fields, $class->getName());
-                if ($fields == null) {
-                  continue;
-                }
-                
+            } elseif (C\contains_key($class_fields, $class->getName())) {
                 $rc = new \ReflectionClass($class->getName());
+                $fields = $class_fields[$class->getName()];
                 $graphql_interface = $rc->getAttributeClass(\Slack\GraphQL\InterfaceType::class);
                 $graphql_object = $rc->getAttributeClass(\Slack\GraphQL\ObjectType::class);
                 invariant(

--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -250,8 +250,12 @@ final class Generator {
                 );
                 $objects = Vec\concat($objects, $this->getConnectionObjects($class, $class_fields[$class->getName()]));
             } elseif (!C\is_empty($class->getAttributes())) {
+                $fields = idx($class_fields, $class->getName());
+                if ($fields == null) {
+                  continue;
+                }
+                
                 $rc = new \ReflectionClass($class->getName());
-                $fields = $class_fields[$class->getName()];
                 $graphql_interface = $rc->getAttributeClass(\Slack\GraphQL\InterfaceType::class);
                 $graphql_object = $rc->getAttributeClass(\Slack\GraphQL\ObjectType::class);
                 invariant(

--- a/tests/Fixtures/Playground.hack
+++ b/tests/Fixtures/Playground.hack
@@ -1,6 +1,5 @@
 
 
-
 use namespace Slack\GraphQL;
 use namespace HH\Lib\{Math, Str, Vec};
 
@@ -252,4 +251,10 @@ final class AlphabetConnection extends GraphQL\Pagination\ListConnection {
     public function __construct() {
         parent::__construct(Str\split('abcdefghijklmnopqrstuvwxyz', ''));
     }
+}
+
+
+<<__ConsistentConstruct>>
+final class NonGraphQLClass {
+
 }


### PR DESCRIPTION
I have a class with a non-graphql attribute class (`<<__ConsistentConstruct>>`) that was being picked up at this line and leading to codegen failures. the code expects my non-graphql class to exist in `$class_fields`, and this PR simply continues if the class has attribute classes but no graphql attribute classes. another solution could be to more narrowly tailor the directories that my codegen script checks, but seems like we should be able to handle this case fairly well.