### PR TITLE
Sort desc bug

### DIFF
--- a/src/Pagination/ListConnection.hack
+++ b/src/Pagination/ListConnection.hack
@@ -18,22 +18,22 @@ abstract class ListConnection extends Connection {
         $end_id = C\count($this->items);
 
         $after = $args['after'] ?? null;
-        if ($after) {
+        if ($after is nonnull) {
             $start_id = Str\to_int($after) as nonnull + 1; // Add one to skip the `after` cursor.
         }
 
         $before = $args['before'] ?? null;
-        if ($before) {
+        if ($before is nonnull) {
             $end_id = Str\to_int($before) as nonnull;
         }
 
         $first = $args['first'] ?? null;
-        if ($first) {
+        if ($first is nonnull) {
             $end_id = Math\minva($end_id, $start_id + $first);
         }
 
         $last = $args['last'] ?? null;
-        if ($last) {
+        if ($last is nonnull) {
             $start_id = Math\maxva($start_id, $end_id - $last);
         }
 

--- a/tests/Fixtures/UserConnection.hack
+++ b/tests/Fixtures/UserConnection.hack
@@ -19,23 +19,23 @@ final class UserConnection extends GraphQL\Pagination\Connection {
     ): Awaitable<vec<GraphQL\Pagination\Edge<User>>> {
         $after = $args['after'] ?? null;
         $start_id = 0;
-        if ($after) {
+        if ($after is nonnull) {
             $start_id = Str\to_int($after) as nonnull + 1; // Add one to skip the `after` cursor.
         }
 
         $before = $args['before'] ?? null;
         $end_id = 5;
-        if ($before) {
+        if ($before is nonnull) {
             $end_id = Str\to_int($before) as nonnull;
         }
 
         $first = $args['first'] ?? null;
-        if ($first) {
+        if ($first is nonnull) {
             $end_id = Math\minva($end_id, $start_id + $first);
         }
 
         $last = $args['last'] ?? null;
-        if ($last) {
+        if ($last is nonnull) {
             $start_id = Math\maxva($start_id, $end_id - $last);
         }
 

--- a/tests/PaginationTest.hack
+++ b/tests/PaginationTest.hack
@@ -13,6 +13,56 @@ final class PaginationTest extends FixtureTest {
     <<__Override>>
     public static function getTestCases(): this::TTestCases {
         return dict[
+            // 'get all' => tuple(
+            //     'query ($after: String!) {
+            //         human(id: 20) {
+            //             friends(first: 1000) {
+            //                 edges {
+            //                     node {
+            //                         id
+            //                         name
+            //                     }
+            //                     cursor
+            //                 }
+            //                 pageInfo {
+            //                     hasNextPage
+            //                     hasPreviousPage
+            //                     startCursor
+            //                     endCursor
+            //                 }
+            //             }
+            //         }
+            //     }',
+            //     dict['after' => base64_encode("1")],
+            //     dict[
+            //         'human' => dict[
+            //             'friends' => dict[
+            //                 'edges' => vec[
+            //                     dict[
+            //                         'node' => dict[
+            //                             'id' => 2,
+            //                             'name' => 'User 2',
+            //                         ],
+            //                         'cursor' => base64_encode('2'),
+            //                     ],
+            //                     dict[
+            //                         'node' => dict[
+            //                             'id' => 3,
+            //                             'name' => 'User 3',
+            //                         ],
+            //                         'cursor' => base64_encode('3'),
+            //                     ],
+            //                 ],
+            //                 'pageInfo' => dict[
+            //                     'hasNextPage' => true,
+            //                     'hasPreviousPage' => false,
+            //                     'startCursor' => base64_encode('2'),
+            //                     'endCursor' => base64_encode('3'),
+            //                 ],
+            //             ],
+            //         ],
+            //     ],
+            // ),
             'test retrieving edges after an index' => tuple(
                 'query ($after: String!) {
                     human(id: 20) {
@@ -55,7 +105,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
-                                'hasPreviousPage' => false,
+                                'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('2'),
                                 'endCursor' => base64_encode('3'),
                             ],
@@ -99,7 +149,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => false,
-                                'hasPreviousPage' => false,
+                                'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('4'),
                                 'endCursor' => base64_encode('4'),
                             ],
@@ -149,7 +199,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
-                                'hasNextPage' => false,
+                                'hasNextPage' => true,
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('2'),
                                 'endCursor' => base64_encode('3'),
@@ -302,7 +352,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
-                                'hasNextPage' => false,
+                                'hasNextPage' => true,
                                 'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('0'),
                                 'endCursor' => base64_encode('0'),
@@ -514,7 +564,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
-                                'hasPreviousPage' => false,
+                                'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('2'),
                                 'endCursor' => base64_encode('3'),
                             ],
@@ -593,7 +643,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
-                                'hasNextPage' => false,
+                                'hasNextPage' => true,
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('22'),
                                 'endCursor' => base64_encode('23'),

--- a/tests/PaginationTest.hack
+++ b/tests/PaginationTest.hack
@@ -13,56 +13,6 @@ final class PaginationTest extends FixtureTest {
     <<__Override>>
     public static function getTestCases(): this::TTestCases {
         return dict[
-            // 'get all' => tuple(
-            //     'query ($after: String!) {
-            //         human(id: 20) {
-            //             friends(first: 1000) {
-            //                 edges {
-            //                     node {
-            //                         id
-            //                         name
-            //                     }
-            //                     cursor
-            //                 }
-            //                 pageInfo {
-            //                     hasNextPage
-            //                     hasPreviousPage
-            //                     startCursor
-            //                     endCursor
-            //                 }
-            //             }
-            //         }
-            //     }',
-            //     dict['after' => base64_encode("1")],
-            //     dict[
-            //         'human' => dict[
-            //             'friends' => dict[
-            //                 'edges' => vec[
-            //                     dict[
-            //                         'node' => dict[
-            //                             'id' => 2,
-            //                             'name' => 'User 2',
-            //                         ],
-            //                         'cursor' => base64_encode('2'),
-            //                     ],
-            //                     dict[
-            //                         'node' => dict[
-            //                             'id' => 3,
-            //                             'name' => 'User 3',
-            //                         ],
-            //                         'cursor' => base64_encode('3'),
-            //                     ],
-            //                 ],
-            //                 'pageInfo' => dict[
-            //                     'hasNextPage' => true,
-            //                     'hasPreviousPage' => false,
-            //                     'startCursor' => base64_encode('2'),
-            //                     'endCursor' => base64_encode('3'),
-            //                 ],
-            //             ],
-            //         ],
-            //     ],
-            // ),
             'test retrieving edges after an index' => tuple(
                 'query ($after: String!) {
                     human(id: 20) {

--- a/tests/PaginationTest.hack
+++ b/tests/PaginationTest.hack
@@ -26,6 +26,7 @@ final class PaginationTest extends FixtureTest {
                             }
                             pageInfo {
                                 hasNextPage
+                                hasPreviousPage
                                 startCursor
                                 endCursor
                             }
@@ -54,6 +55,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
+                                'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('2'),
                                 'endCursor' => base64_encode('3'),
                             ],
@@ -75,6 +77,7 @@ final class PaginationTest extends FixtureTest {
                             }
                             pageInfo {
                                 hasNextPage
+                                hasPreviousPage
                                 startCursor
                                 endCursor
                             }
@@ -96,6 +99,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => false,
+                                'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('4'),
                                 'endCursor' => base64_encode('4'),
                             ],
@@ -116,6 +120,7 @@ final class PaginationTest extends FixtureTest {
                                 cursor
                             }
                             pageInfo {
+                                hasNextPage
                                 hasPreviousPage
                                 startCursor
                                 endCursor
@@ -144,6 +149,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
+                                'hasNextPage' => false,
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('2'),
                                 'endCursor' => base64_encode('3'),
@@ -166,6 +172,7 @@ final class PaginationTest extends FixtureTest {
                             }
                             pageInfo {
                                 hasNextPage
+                                hasPreviousPage
                                 startCursor
                                 endCursor
                             }
@@ -194,6 +201,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
+                                'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('0'),
                                 'endCursor' => base64_encode('1'),
                             ],
@@ -272,6 +280,7 @@ final class PaginationTest extends FixtureTest {
                                 cursor
                             }
                             pageInfo {
+                                hasNextPage
                                 hasPreviousPage
                                 startCursor
                                 endCursor
@@ -293,6 +302,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
+                                'hasNextPage' => false,
                                 'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('0'),
                                 'endCursor' => base64_encode('0'),
@@ -314,6 +324,7 @@ final class PaginationTest extends FixtureTest {
                                 cursor
                             }
                             pageInfo {
+                                hasNextPage
                                 hasPreviousPage
                                 startCursor
                                 endCursor
@@ -342,6 +353,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
+                                'hasNextPage' => false,
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('3'),
                                 'endCursor' => base64_encode('4'),
@@ -364,6 +376,7 @@ final class PaginationTest extends FixtureTest {
                             }
                             pageInfo {
                                 hasNextPage
+                                hasPreviousPage
                                 startCursor
                                 endCursor
                             }
@@ -385,6 +398,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
+                                'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('0'),
                                 'endCursor' => base64_encode('0'),
                             ],
@@ -405,6 +419,7 @@ final class PaginationTest extends FixtureTest {
                                 cursor
                             }
                             pageInfo {
+                                hasNextPage
                                 hasPreviousPage
                                 startCursor
                                 endCursor
@@ -437,6 +452,7 @@ final class PaginationTest extends FixtureTest {
                         }
                         pageInfo {
                             hasNextPage
+                            hasPreviousPage
                             startCursor
                             endCursor
                         }
@@ -458,6 +474,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
+                                'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('0'),
                                 'endCursor' => base64_encode('1'),
                             ],
@@ -475,6 +492,7 @@ final class PaginationTest extends FixtureTest {
                         }
                         pageInfo {
                             hasNextPage
+                            hasPreviousPage
                             startCursor
                             endCursor
                         }
@@ -496,6 +514,7 @@ final class PaginationTest extends FixtureTest {
                             ],
                             'pageInfo' => dict[
                                 'hasNextPage' => true,
+                                'hasPreviousPage' => false,
                                 'startCursor' => base64_encode('2'),
                                 'endCursor' => base64_encode('3'),
                             ],
@@ -512,6 +531,7 @@ final class PaginationTest extends FixtureTest {
                             cursor
                         }
                         pageInfo {
+                            hasNextPage
                             hasPreviousPage 
                             startCursor
                             endCursor
@@ -533,6 +553,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
+                                'hasNextPage' => false,
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('24'),
                                 'endCursor' => base64_encode('25'),
@@ -550,6 +571,7 @@ final class PaginationTest extends FixtureTest {
                             cursor
                         }
                         pageInfo {
+                            hasNextPage
                             hasPreviousPage 
                             startCursor
                             endCursor
@@ -571,6 +593,7 @@ final class PaginationTest extends FixtureTest {
                                 ],
                             ],
                             'pageInfo' => dict[
+                                'hasNextPage' => false,
                                 'hasPreviousPage' => true,
                                 'startCursor' => base64_encode('22'),
                                 'endCursor' => base64_encode('23'),


### PR DESCRIPTION
When retrieving a list of items the project will grab 1 extra to cleverly figure out if there is a next page. However the project always assumes the list is sort ascending, when sending a descending list it doesn't remove the extra item but the item at the other end of the list.

To avoid adding sort direction to the project I removed the cleverness, and instead just fetch a single item of the next page to see if there is more

I also renamed
hasPageBeforeAfterCursor > hasNextPage
hasPageAfterBeforeCursor > hasPreviousPage
because I thought they were more clear