### PR TITLE
Page cursor

### DIFF
--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -89,7 +89,27 @@ abstract class Connection {
      * Whether a page exists before the `after` cursor, was such a cursor provided.
      * Can be overridden for efficiency.
      */
-    public async function hasNextPage(PaginationArgs $args, string $start_cursor, string $end_cursor): Awaitable<bool> {
+    protected async function hasNextPage(
+        PaginationArgs $args,
+        string $start_cursor,
+        string $end_cursor,
+    ): Awaitable<bool> {
+        if (
+            Shapes::keyExists($args, 'last') &&
+            !Shapes::keyExists($args, 'before') &&
+            !Shapes::keyExists($args, 'after')
+        ) {
+            return false;
+        }
+
+        if (
+            Shapes::keyExists($args, 'after') &&
+            !Shapes::keyExists($args, 'first') &&
+            !Shapes::keyExists($args, 'before')
+        ) {
+            return false;
+        }
+
         return C\count(await $this->fetch(shape('first' => 1, 'after' => $end_cursor))) > 0;
     }
 
@@ -97,11 +117,27 @@ abstract class Connection {
      * Whether a page exists after the `before` cursor, was such a cursor provided.
      * Can be overridden for efficiency.
      */
-    public async function hasPreviousPage(
+    protected async function hasPreviousPage(
         PaginationArgs $args,
         string $start_cursor,
         string $end_cursor,
     ): Awaitable<bool> {
+        if (
+            Shapes::keyExists($args, 'first') &&
+            !Shapes::keyExists($args, 'before') &&
+            !Shapes::keyExists($args, 'after')
+        ) {
+            return false;
+        }
+
+        if (
+            Shapes::keyExists($args, 'before') &&
+            !Shapes::keyExists($args, 'last') &&
+            !Shapes::keyExists($args, 'after')
+        ) {
+            return false;
+        }
+
         return C\count(await $this->fetch(shape('last' => 1, 'before' => $start_cursor))) > 0;
     }
 

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -94,15 +94,7 @@ abstract class Connection {
         string $start_cursor,
         string $end_cursor,
     ): Awaitable<bool> {
-        if (Shapes::keyExists($args, 'last') && !Shapes::keyExists($args, 'before')) {
-            return false;
-        }
-
-        if (
-            Shapes::keyExists($args, 'after') &&
-            !Shapes::keyExists($args, 'first') &&
-            !Shapes::keyExists($args, 'before')
-        ) {
+        if (!Shapes::keyExists($args, 'first') && !Shapes::keyExists($args, 'before')) {
             return false;
         }
 
@@ -118,15 +110,7 @@ abstract class Connection {
         string $start_cursor,
         string $end_cursor,
     ): Awaitable<bool> {
-        if (Shapes::keyExists($args, 'first') && !Shapes::keyExists($args, 'after')) {
-            return false;
-        }
-
-        if (
-            Shapes::keyExists($args, 'before') &&
-            !Shapes::keyExists($args, 'last') &&
-            !Shapes::keyExists($args, 'after')
-        ) {
+        if (!Shapes::keyExists($args, 'last') && !Shapes::keyExists($args, 'after')) {
             return false;
         }
 

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -89,7 +89,7 @@ abstract class Connection {
      * Whether a page exists before the `after` cursor, was such a cursor provided.
      * Can be overridden for efficiency.
      */
-    public async function hasNextPage(string $start_cursor, string $end_cursor): Awaitable<bool> {
+    public async function hasNextPage(PaginationArgs $args, string $start_cursor, string $end_cursor): Awaitable<bool> {
         return C\count(await $this->fetch(shape('first' => 1, 'after' => $end_cursor))) > 0;
     }
 
@@ -97,7 +97,11 @@ abstract class Connection {
      * Whether a page exists after the `before` cursor, was such a cursor provided.
      * Can be overridden for efficiency.
      */
-    public async function hasPreviousPage(string $start_cursor, string $end_cursor): Awaitable<bool> {
+    public async function hasPreviousPage(
+        PaginationArgs $args,
+        string $start_cursor,
+        string $end_cursor,
+    ): Awaitable<bool> {
         return C\count(await $this->fetch(shape('last' => 1, 'before' => $start_cursor))) > 0;
     }
 
@@ -167,10 +171,12 @@ abstract class Connection {
             $page_info['startCursor'] = C\firstx($edges)->getCursor();
             $page_info['endCursor'] = C\lastx($edges)->getCursor();
             $page_info['hasNextPage'] = await $this->hasNextPage(
+                $this->args,
                 $this->decodeCursor($page_info['startCursor']),
                 $this->decodeCursor($page_info['endCursor']),
             );
             $page_info['hasPreviousPage'] = await $this->hasPreviousPage(
+                $this->args,
                 $this->decodeCursor($page_info['startCursor']),
                 $this->decodeCursor($page_info['endCursor']),
             );

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -94,6 +94,10 @@ abstract class Connection {
         string $start_cursor,
         string $end_cursor,
     ): Awaitable<bool> {
+        if (Shapes::keyExists($args, 'last') && !Shapes::keyExists($args, 'before')) {
+            return false;
+        }
+
         if (!Shapes::keyExists($args, 'first') && !Shapes::keyExists($args, 'before')) {
             return false;
         }
@@ -110,6 +114,10 @@ abstract class Connection {
         string $start_cursor,
         string $end_cursor,
     ): Awaitable<bool> {
+        if (Shapes::keyExists($args, 'first') && !Shapes::keyExists($args, 'after')) {
+            return false;
+        }
+
         if (!Shapes::keyExists($args, 'last') && !Shapes::keyExists($args, 'after')) {
             return false;
         }

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -94,11 +94,7 @@ abstract class Connection {
         string $start_cursor,
         string $end_cursor,
     ): Awaitable<bool> {
-        if (
-            Shapes::keyExists($args, 'last') &&
-            !Shapes::keyExists($args, 'before') &&
-            !Shapes::keyExists($args, 'after')
-        ) {
+        if (Shapes::keyExists($args, 'last') && !Shapes::keyExists($args, 'before')) {
             return false;
         }
 
@@ -122,11 +118,7 @@ abstract class Connection {
         string $start_cursor,
         string $end_cursor,
     ): Awaitable<bool> {
-        if (
-            Shapes::keyExists($args, 'first') &&
-            !Shapes::keyExists($args, 'before') &&
-            !Shapes::keyExists($args, 'after')
-        ) {
+        if (Shapes::keyExists($args, 'first') && !Shapes::keyExists($args, 'after')) {
             return false;
         }
 

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -198,16 +198,12 @@ abstract class Connection {
         if (!C\is_empty($edges)) {
             $page_info['startCursor'] = C\firstx($edges)->getCursor();
             $page_info['endCursor'] = C\lastx($edges)->getCursor();
-            $page_info['hasNextPage'] = await $this->hasNextPage(
-                $this->args,
-                $this->decodeCursor($page_info['startCursor']),
-                $this->decodeCursor($page_info['endCursor']),
-            );
-            $page_info['hasPreviousPage'] = await $this->hasPreviousPage(
-                $this->args,
-                $this->decodeCursor($page_info['startCursor']),
-                $this->decodeCursor($page_info['endCursor']),
-            );
+            $decoded_start_cursor = $this->decodeCursor($page_info['startCursor']);
+            $decoded_end_cursor = $this->decodeCursor($page_info['endCursor']);
+            $page_info['hasNextPage'] =
+                await $this->hasNextPage($this->args, $decoded_start_cursor, $decoded_end_cursor);
+            $page_info['hasPreviousPage'] =
+                await $this->hasPreviousPage($this->args, $decoded_start_cursor, $decoded_end_cursor);
         }
 
         return shape('edges' => $edges, 'pageInfo' => $page_info);


### PR DESCRIPTION
passes more params to hasNextPage/hasPreviousPage which allows for more complex overriding. This is especally necessary when using SQL with graphql. As you have to artificially change the sort order in SQL to retrieve things, thus changing which start or end cursor to use for the next/prev page