### PR TITLE
allow better subclassing of Connection

### DIFF
--- a/src/Codegen/Generator.hack
+++ b/src/Codegen/Generator.hack
@@ -242,7 +242,11 @@ final class Generator {
         }
 
         foreach ($classish_objects as $class) {
-            if (\is_subclass_of($class->getName(), \Slack\GraphQL\Pagination\Connection::class)) {
+            $rc = new \ReflectionClass($class->getName());
+            if (
+                \is_subclass_of($class->getName(), \Slack\GraphQL\Pagination\Connection::class) &&
+                $rc->getAttributeClass(\Slack\GraphQL\ObjectType::class)
+            ) {
                 invariant(
                     Str\ends_with($class->getName(), 'Connection'),
                     "All connection types must have names ending with `Connection`. `%s` does not.",

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -50,6 +50,7 @@ type PaginationArgs = shape(
  * @see https://relay.dev/graphql/connections.htm for more information about GraphQL pagination.
  * @see src/playground/UserConnection.hack for an example.
  */
+ <<GraphQL\ObjectType('Connection', 'Connection')>>
 abstract class Connection {
 
     /**
@@ -57,6 +58,7 @@ abstract class Connection {
      *
      * This should be the Hack class over which you want to paginate.
      */
+     <<__Enforceable>>
     abstract const type TNode;
 
     /**

--- a/src/Pagination/Connection.hack
+++ b/src/Pagination/Connection.hack
@@ -50,7 +50,6 @@ type PaginationArgs = shape(
  * @see https://relay.dev/graphql/connections.htm for more information about GraphQL pagination.
  * @see src/playground/UserConnection.hack for an example.
  */
- <<GraphQL\ObjectType('Connection', 'Connection')>>
 abstract class Connection {
 
     /**


### PR DESCRIPTION
allow subclassing Connection without having to instantiate abstract constants in an abstract subclass
aka Connection > SqlConnection > UserConnection (don't require SqlConnection to have to instantiate TNode)

Also make TNode abstract type enforceable