### PR TITLE
Support custom input types

### DIFF
--- a/src/Codegen/Builders/CompositeBuilder.hack
+++ b/src/Codegen/Builders/CompositeBuilder.hack
@@ -21,11 +21,12 @@ use type Facebook\HackCodegen\{
 abstract class CompositeBuilder extends OutputTypeBuilder<\Slack\GraphQL\__Private\CompositeType> {
 
     public function __construct(
+        Context $ctx,
         \Slack\GraphQL\__Private\CompositeType $type_info,
         string $hack_type,
         protected vec<FieldBuilder> $fields,
     ) {
-        parent::__construct($type_info, $hack_type);
+        parent::__construct($ctx, $type_info, $hack_type);
     }
 
     public function build(HackCodegenFactory $cg): CodegenClass {

--- a/src/Codegen/Builders/Fields/IntrospectionSchemaFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/IntrospectionSchemaFieldBuilder.hack
@@ -11,11 +11,14 @@ final class IntrospectSchemaFieldBuilder extends FieldBuilder {
         ...
     );
 
-    public function __construct() {
-        parent::__construct(shape(
-            'name' => '__schema',
-            'output_type' => shape('type' => '__Schema::nullableOutput()'),
-        ));
+    public function __construct(Context $ctx) {
+        parent::__construct(
+            $ctx,
+            shape(
+                'name' => '__schema',
+                'output_type' => shape('type' => '__Schema::nullableOutput()'),
+            ),
+        );
     }
 
     <<__Override>>

--- a/src/Codegen/Builders/Fields/IntrospectionTypeFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/IntrospectionTypeFieldBuilder.hack
@@ -6,16 +6,19 @@ use type Facebook\HackCodegen\{HackBuilder};
 
 final class IntrospectTypeFieldBuilder extends MethodFieldBuilder {
 
-    public function __construct() {
-        parent::__construct(shape(
-            'name' => '__type',
-            'method_name' => '_',
-            'output_type' => shape('type' => '__Type::nullableOutput()'),
-            'root_field_for_type' => 'Schema',
-            'parameters' => vec[
-                shape('name' => 'name', 'type' => 'HH\string', 'is_optional' => false),
-            ],
-        ));
+    public function __construct(Context $ctx) {
+        parent::__construct(
+            $ctx,
+            shape(
+                'name' => '__type',
+                'method_name' => '_',
+                'output_type' => shape('type' => '__Type::nullableOutput()'),
+                'root_field_for_type' => 'Schema',
+                'parameters' => vec[
+                    shape('name' => 'name', 'type' => 'HH\string', 'is_optional' => false),
+                ],
+            ),
+        );
     }
     <<__Override>>
     protected function generateResolverBody(HackBuilder $hb): void {

--- a/src/Codegen/Builders/Fields/MethodFieldBuilder.hack
+++ b/src/Codegen/Builders/Fields/MethodFieldBuilder.hack
@@ -80,7 +80,7 @@ class MethodFieldBuilder extends FieldBuilder {
     final protected function getArgumentInvocationString(Parameter $param): string {
         return Str\format(
             '%s->coerce%sNamedNode(%s, $args, $vars%s)',
-            input_type($param['type']),
+            input_type($param['type'], $this->ctx->getCustomTypes()),
             $param['is_optional'] ? 'Optional' : '',
             \var_export($param['name'], true),
             Shapes::keyExists($param, 'default_value') ? ', '.$param['default_value'] : '',

--- a/src/Codegen/Builders/InterfaceBuilder.hack
+++ b/src/Codegen/Builders/InterfaceBuilder.hack
@@ -17,12 +17,13 @@ final class InterfaceBuilder extends CompositeBuilder {
 
     <<__Override>>
     public function __construct(
+        Context $ctx,
         \Slack\GraphQL\__Private\CompositeType $type_info,
         string $hack_type,
         vec<FieldBuilder> $fields,
         private dict<string, string> $hack_class_to_graphql_object,
     ) {
-        parent::__construct($type_info, $hack_type, $fields);
+        parent::__construct($ctx, $type_info, $hack_type, $fields);
     }
 
     <<__Override>>

--- a/src/Codegen/Builders/TypeBuilder.hack
+++ b/src/Codegen/Builders/TypeBuilder.hack
@@ -24,7 +24,7 @@ abstract class TypeBuilder<T as \Slack\GraphQL\__Private\GraphQLTypeInfo> {
 
     abstract const classname<\Slack\GraphQL\Types\BaseType> SUPERCLASS;
 
-    public function __construct(protected T $type_info, protected string $hack_type) {}
+    public function __construct(protected Context $ctx, protected T $type_info, protected string $hack_type) {}
 
     final public function getGraphQLType(): string {
         return $this->type_info->getType();

--- a/src/Codegen/Context.hack
+++ b/src/Codegen/Context.hack
@@ -1,0 +1,11 @@
+
+
+namespace Slack\GraphQL\Codegen;
+
+final class Context {
+    public function __construct(private dict<string, classname<\Slack\GraphQL\Types\NamedType>> $custom_types) {}
+
+    public function getCustomTypes(): dict<string, classname<\Slack\GraphQL\Types\NamedType>> {
+        return $this->custom_types;
+    }
+}

--- a/src/Codegen/FieldResolver.hack
+++ b/src/Codegen/FieldResolver.hack
@@ -14,7 +14,7 @@ final class FieldResolver {
     private dict<string, DefinitionFinder\ScannedClassish> $scanned_classes;
     private dict<string, dict<string, FieldBuilder>> $resolved_fields = dict[];
 
-    public function __construct(vec<DefinitionFinder\ScannedClassish> $classes) {
+    public function __construct(private Context $ctx, vec<DefinitionFinder\ScannedClassish> $classes) {
         $this->scanned_classes = Dict\from_values($classes, $class ==> $class->getName());
     }
 
@@ -77,7 +77,7 @@ final class FieldResolver {
             $graphql_field = $rm->getAttributeClass(\Slack\GraphQL\Field::class);
             if ($graphql_field is null) continue;
 
-            $fields[$graphql_field->getName()] = FieldBuilder::fromReflectionMethod($graphql_field, $rm);
+            $fields[$graphql_field->getName()] = FieldBuilder::fromReflectionMethod($this->ctx, $graphql_field, $rm);
         }
 
         return $fields;

--- a/src/Request.hack
+++ b/src/Request.hack
@@ -1,3 +1,6 @@
+
+
+
 namespace Slack\GraphQL;
 
 use namespace Slack\GraphQL;

--- a/src/Response.hack
+++ b/src/Response.hack
@@ -1,3 +1,6 @@
+
+
+
 namespace Slack\GraphQL;
 
 use namespace HH\Lib\Vec;

--- a/tests/FixtureTest.hack
+++ b/tests/FixtureTest.hack
@@ -23,6 +23,10 @@ abstract class FixtureTest extends \Facebook\HackTest\HackTest {
             shape(
                 'output_directory' => __DIR__.'/gen',
                 'namespace' => 'Slack\GraphQL\Test\Generated',
+                'custom_types' => dict[
+                    Channel::class => ChannelInputType::class,
+                    user_id_t::class => UserIdInputType::class,
+                ],
             ),
         );
     }

--- a/tests/Fixtures/ChannelInputType.hack
+++ b/tests/Fixtures/ChannelInputType.hack
@@ -1,0 +1,41 @@
+
+use namespace Graphpinator\Parser\Value;
+use namespace Slack\GraphQL;
+
+final class Channel {
+    public function __construct(private string $input) {}
+}
+
+final class ChannelInputType extends GraphQL\Types\NamedType {
+    use GraphQL\Types\TNamedInputType;
+    use GraphQL\Types\TNonNullableType;
+
+    const string NAME = 'ChannelID';
+    const type THackType = Channel;
+
+    <<__Override>>
+    final public function assertValidVariableValue(mixed $value): Channel {
+        return $value as Channel;
+    }
+
+    <<__Override>>
+    public function coerceValue(mixed $value): Channel {
+        if (!$value is string) {
+            throw new GraphQL\UserFacingError('Expected a ChannelID, got %s', (string)$value);
+        }
+        return new Channel($value);
+    }
+
+    <<__Override>>
+    final public function coerceNonVariableNode(Value\Value $node, dict<string, mixed> $variable_values): Channel {
+        if (!$node is Value\StringLiteral) {
+            throw new GraphQL\UserFacingError('Expected an ChannelID literal, got %s', \get_class($node));
+        }
+        return new Channel($node->getRawValue());
+    }
+
+    <<__Override>>
+    final public function getKind(): GraphQL\Introspection\__TypeKind {
+        return GraphQL\Introspection\__TypeKind::SCALAR;
+    }
+}

--- a/tests/Fixtures/Playground.hack
+++ b/tests/Fixtures/Playground.hack
@@ -167,7 +167,8 @@ abstract final class UserQueryAttributes {
     }
 
     <<GraphQL\QueryRootField('user', 'Fetch a user by ID')>>
-    public static async function getUser(int $id): Awaitable<\User> {
+    public static async function getUser(user_id_t $id): Awaitable<\User> {
+        $id = user_id_to_int($id);
         return new \Human(shape('id' => $id, 'name' => 'User '.$id, 'team_id' => 1, 'is_active' => true));
     }
 
@@ -242,6 +243,11 @@ abstract final class UserMutationAttributes {
             'team_id' => $team?->getId() ?? 1,
             'roles' => $input['roles'] ?? vec[],
         ));
+    }
+
+    <<GraphQL\QueryRootField('mutateChannel', 'Update the channel')>>
+    public static function mutateChannel(Channel $channel): bool {
+        return true;
     }
 }
 

--- a/tests/Fixtures/UserIdInputType.hack
+++ b/tests/Fixtures/UserIdInputType.hack
@@ -1,0 +1,43 @@
+
+use namespace Graphpinator\Parser\Value;
+use namespace Slack\GraphQL;
+
+newtype user_id_t = int;
+
+function user_id_to_int(user_id_t $user_id): int {
+    return $user_id;
+}
+
+final class UserIdInputType extends GraphQL\Types\NamedType {
+    use GraphQL\Types\TNamedInputType;
+    use GraphQL\Types\TNonNullableType;
+
+    const string NAME = 'UserID';
+    const type THackType = user_id_t;
+
+    <<__Override>>
+    final public function assertValidVariableValue(mixed $value): user_id_t {
+        return $value as user_id_t;
+    }
+
+    <<__Override>>
+    public function coerceValue(mixed $value): user_id_t {
+        if (!$value is int) {
+            throw new GraphQL\UserFacingError('Expected a UserId, got %s', (string)$value);
+        }
+        return $value;
+    }
+
+    <<__Override>>
+    final public function coerceNonVariableNode(Value\Value $node, dict<string, mixed> $variable_values): user_id_t {
+        if (!$node is Value\IntLiteral) {
+            throw new GraphQL\UserFacingError('Expected a UserId literal, got %s', \get_class($node));
+        }
+        return $node->getRawValue();
+    }
+
+    <<__Override>>
+    final public function getKind(): GraphQL\Introspection\__TypeKind {
+        return GraphQL\Introspection\__TypeKind::SCALAR;
+    }
+}

--- a/tests/Validation/BaseValidationTest.hack
+++ b/tests/Validation/BaseValidationTest.hack
@@ -24,6 +24,10 @@ abstract class BaseValidationTest extends \Facebook\HackTest\HackTest {
             shape(
                 'output_directory' => __DIR__.'/../gen',
                 'namespace' => 'Slack\GraphQL\Test\Generated',
+                'custom_types' => dict[
+                    Channel::class => ChannelInputType::class,
+                    user_id_t::class => UserIdInputType::class,
+                ],
             ),
         );
     }

--- a/tests/gen/Query.hack
+++ b/tests/gen/Query.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<fa1ca424a98ff51976408a73d53305d4>>
+ * @generated SignedSource<<483338310fc52d714e54c4e4673f1a44>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -31,6 +31,7 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
     'human',
     'introspection_test',
     'list_arg_test',
+    'mutateChannel',
     'nested_list_sum',
     'optional_field_test',
     'output_type_test',
@@ -263,6 +264,20 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
             Types\IntType::nonNullable()->nullableInputListOf()->nonNullableInputListOf()->nullableInputListOf()->coerceNamedNode('arg', $args, $vars),
           ),
         );
+      case 'mutateChannel':
+        return new GraphQL\FieldDefinition(
+          'mutateChannel',
+          Types\BooleanType::nullableOutput(),
+          dict[
+            'channel' => shape(
+              'name' => 'channel',
+              'type' => \ChannelInputType::nonNullable(),
+            ),
+          ],
+          async ($parent, $args, $vars) ==> \UserMutationAttributes::mutateChannel(
+            \ChannelInputType::nonNullable()->coerceNamedNode('channel', $args, $vars),
+          ),
+        );
       case 'nested_list_sum':
         return new GraphQL\FieldDefinition(
           'nested_list_sum',
@@ -319,11 +334,11 @@ final class Query extends \Slack\GraphQL\Types\ObjectType {
           dict[
             'id' => shape(
               'name' => 'id',
-              'type' => Types\IntType::nonNullable(),
+              'type' => \UserIdInputType::nonNullable(),
             ),
           ],
           async ($parent, $args, $vars) ==> await \UserQueryAttributes::getUser(
-            Types\IntType::nonNullable()->coerceNamedNode('id', $args, $vars),
+            \UserIdInputType::nonNullable()->coerceNamedNode('id', $args, $vars),
           ),
         );
       case 'viewer':

--- a/tests/gen/Schema.hack
+++ b/tests/gen/Schema.hack
@@ -4,7 +4,7 @@
  * To re-generate this file run vendor/bin/hacktest
  *
  *
- * @generated SignedSource<<aa619418da13779e3b131b1993721d03>>
+ * @generated SignedSource<<f6d9391ae49b9645e76d94f7aa6aab7e>>
  */
 namespace Slack\GraphQL\Test\Generated;
 use namespace Slack\GraphQL;
@@ -19,6 +19,7 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
     'Baz' => Baz::class,
     'Boolean' => Types\BooleanType::class,
     'Bot' => Bot::class,
+    'ChannelID' => \ChannelInputType::class,
     'Concrete' => Concrete::class,
     'CreateTeamInput' => CreateTeamInput::class,
     'CreateUserInput' => CreateUserInput::class,
@@ -56,6 +57,7 @@ final class Schema extends \Slack\GraphQL\BaseSchema {
     'User' => User::class,
     'UserConnection' => UserConnection::class,
     'UserEdge' => UserEdge::class,
+    'UserID' => \UserIdInputType::class,
     '__Directive' => __Directive::class,
     '__EnumValue' => __EnumValue::class,
     '__Field' => __Field::class,

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -199,6 +199,15 @@
                     "possibleTypes": null
                 },
                 {
+                    "kind": "SCALAR",
+                    "name": "ChannelID",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
                     "kind": "OBJECT",
                     "name": "Concrete",
                     "fields": [
@@ -2046,6 +2055,31 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "mutateChannel",
+                            "args": [
+                                {
+                                    "name": "channel",
+                                    "type": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "ChannelID",
+                                            "ofType": null
+                                        }
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "nested_list_sum",
                             "args": [
                                 {
@@ -2157,7 +2191,7 @@
                                         "name": null,
                                         "ofType": {
                                             "kind": "SCALAR",
-                                            "name": "Int",
+                                            "name": "UserID",
                                             "ofType": null
                                         }
                                     },
@@ -2482,6 +2516,15 @@
                     ],
                     "inputFields": null,
                     "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "SCALAR",
+                    "name": "UserID",
+                    "fields": null,
+                    "inputFields": null,
+                    "interfaces": null,
                     "enumValues": null,
                     "possibleTypes": null
                 },


### PR DESCRIPTION
Allow registering custom input types. This seems really useful from a security standpoint: when coercing input to a Hack type, the GraphQL type itself can verify that the viewer has access to the resource using global context. 

I haven't done any work to make defining custom types ergonomic. You have to subclass `NamedType` and then use `TNamedInputType` and `TNonNullableType`. We could definitely make this nicer.

I'm also not sure this works as-is with clients. For example, `ChannelID` is a new scalar type which takes a string and outputs a Channel object. Will clients understand that when they see `ChannelID`, they should provide a string?
